### PR TITLE
Add initial example and template for siteinfo and formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SHELL=/bin/bash
+ALL=$(shell cd formats; find . -name '*.jsonnet' \
+	        | sed -e 's/\.\///' -e 's/.jsonnet//g' )
+
+DEPS=sites.jsonnet sites/_default.jsonnet
+
+all: $(ALL)
+
+%.json: formats/%.json.jsonnet $(DEPS)
+	time jsonnet -J . $< > $@
+
+fmt:
+	@for f in `find . -name "*.jsonnet"` ; do \
+        jsonnet fmt --indent 2 --max-blank-lines 2 --sort-imports \
+		            --string-style s --comment-style s $$f | diff $$f - ; \
+	    jsonnet fmt --in-place $$f ; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ all: $(ALL)
 	time jsonnet -J . $< > $@
 
 fmt:
-	@for f in `find . -name "*.jsonnet"` ; do \
-        jsonnet fmt --indent 2 --max-blank-lines 2 --sort-imports \
-		            --string-style s --comment-style s $$f | diff $$f - ; \
+	@find . -name '*.jsonnet' -print0 | \
+	  while read -d \\0 f; do \
+      jsonnet fmt --indent 2 --max-blank-lines 2 --sort-imports \
+		              --string-style s --comment-style s $$f | diff $$f - ; \
 	    jsonnet fmt --in-place $$f ; \
-	done
+	  done

--- a/formats/mlab-site-info.json.jsonnet
+++ b/formats/mlab-site-info.json.jsonnet
@@ -1,0 +1,17 @@
+local sites = import 'sites.jsonnet';
+[
+  {
+    local location = sites[name].location,
+    city: location.city,
+    metro: [
+      name,
+      location.metro,
+    ],
+    country: location.country_code,
+    site: name,
+    longitude: location.longitude,
+    latitude: location.latitude,
+    roundrobin: sites[name].loadbalancer.roundrobin,
+  }
+  for name in std.objectFields(sites)
+]

--- a/formats/mlab-site-info.json.jsonnet
+++ b/formats/mlab-site-info.json.jsonnet
@@ -1,17 +1,17 @@
 local sites = import 'sites.jsonnet';
 [
   {
-    local location = sites[name].location,
+    local location = site.location,
     city: location.city,
     metro: [
-      name,
+      site.name,
       location.metro,
     ],
     country: location.country_code,
-    site: name,
+    site: site.name,
     longitude: location.longitude,
     latitude: location.latitude,
-    roundrobin: sites[name].loadbalancer.roundrobin,
+    roundrobin: site.loadbalancer.roundrobin,
   }
-  for name in std.objectFields(sites)
+  for site in sites
 ]

--- a/formats/raw-sites.json.jsonnet
+++ b/formats/raw-sites.json.jsonnet
@@ -1,0 +1,1 @@
+import 'sites.jsonnet'

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -3,9 +3,10 @@ local sites = {
    tyo01: import 'sites/tyo01.jsonnet'
 };
 [
-  if sites[name].name == name then
-      sites[name]
+  local site = sites[name];
+  if site.name == name then
+      site
   else
-      error "Site name (%s) does not match object.name (%s)" % [name, sites[name].name],
+      error "Site name (%s) does not match object.name (%s)" % [name, site.name],
   for name in std.objectFields(sites)
 ]

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -3,7 +3,9 @@ local sites = {
    tyo01: import 'sites/tyo01.jsonnet'
 };
 [
-  sites[name],
+  if sites[name].name == name then
+      sites[name]
+  else
+      error "Site name (%s) does not match object.name (%s)" % [name, sites[name].name],
   for name in std.objectFields(sites)
-  if sites[name].name == name
 ]

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -1,4 +1,13 @@
+//[
+// import 'sites/lga0t.jsonnet',
+// import 'sites/tyo01.jsonnet',
+//]
+local sites = {
+   lga0t: import 'sites/lga0t.jsonnet',
+   tyo01: import 'sites/tyo01.jsonnet'
+};
 [
-  import 'sites/lga0t.jsonnet',
-  import 'sites/tyo01.jsonnet',
+  sites[name],
+  for name in std.objectFields(sites)
+  if sites[name].name == name
 ]

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -1,7 +1,3 @@
-//[
-// import 'sites/lga0t.jsonnet',
-// import 'sites/tyo01.jsonnet',
-//]
 local sites = {
    lga0t: import 'sites/lga0t.jsonnet',
    tyo01: import 'sites/tyo01.jsonnet'

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -1,4 +1,4 @@
-{
-  lga0t: import 'sites/lga0t.jsonnet',
-  tyo01: import 'sites/tyo01.jsonnet',
-}
+[
+  import 'sites/lga0t.jsonnet',
+  import 'sites/tyo01.jsonnet',
+]

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -1,0 +1,4 @@
+{
+  lga0t: import 'sites/lga0t.jsonnet',
+  tyo01: import 'sites/tyo01.jsonnet',
+}

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -1,5 +1,5 @@
 {
-  name: error 'Must override annotations.name',
+  name: error 'Must override site name',
   annotations: {
     type: error 'Must override annotations.type, e.g. physical, cloud',
   },

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -1,0 +1,47 @@
+{
+  name: error 'Must override annotations.name',
+  annotations: {
+    type: error 'Must override annotations.type, e.g. physical, cloud',
+  },
+  loadbalancer: {
+    roundrobin: true,
+  },
+  machines: {
+    count: 4,
+    disk: 'sda',
+    iface: 'eth0',
+  },
+  network: {
+    ipv4: {
+      prefix: error 'Must override network.ipv4.prefix',
+      dns1: '8.8.8.8',
+      dns2: '8.8.4.4',
+    },
+    ipv6: {
+      prefix: error 'Must override network.ipv6.prefix',
+      dns1: '2001:4860:4860::8888',
+      dns2: '2001:4860:4860::8844',
+    },
+  },
+  transit: {
+    provider: error 'Must override transit.provider',
+    uplink: error 'Must override transit.uplink',
+  },
+  switch: {
+    auto_negotiation: 'yes',
+    flow_control: 'yes',
+  },
+  location: {
+    continent_code: error 'Must override location.continent_code',
+    country_code: error 'Must override location.country_code',
+    metro: error 'Must override location.metro',
+    city: error 'Must override location.city',
+    state: error 'Must override location.state',
+    latitude: error 'Must override location.latitude',
+    longitude: error 'Must override location.longitude',
+  },
+  lifecycle: {
+    created: error 'Must override lifecycle.created',
+    retired: null,
+  },
+}

--- a/sites/lga0t.jsonnet
+++ b/sites/lga0t.jsonnet
@@ -1,0 +1,32 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'lga0t',
+  annotations+: {
+    type: 'physical',
+  },
+  network+: {
+    ipv4+: {
+      prefix: '4.14.159.64/26',
+    },
+    ipv6+: {
+      prefix: '2001:1900:2100:2d::/64',
+    },
+  },
+  transit+: {
+    provider: 'Level3',
+    uplink: '10g',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'lga',
+    city: 'New York',
+    state: 'NY',
+    latitude: 40.766700,
+    longitude: -73.866700,
+  },
+  lifecycle+: {
+    created: '2018-01-01',
+  },
+}

--- a/sites/tyo01.jsonnet
+++ b/sites/tyo01.jsonnet
@@ -1,0 +1,35 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'tyo01',
+  annotations+: {
+    type: 'cloud',
+  },
+  machines+: {
+    count: 1,
+  },
+  network+: {
+    ipv4+: {
+      prefix: '35.200.102.226/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google',
+    uplink: '1g',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'JP',
+    metro: 'tyo',
+    city: 'Tokyo',
+    state: 'NY',
+    latitude: 35.5522,
+    longitude: 139.78,
+  },
+  lifecycle+: {
+    created: '2018-01-01',
+  },
+}


### PR DESCRIPTION
This change is the first commit that illustrates how we could move the m-lab/operator/plsync sites.py and slices.py configuration to a more flexible, complete, and representative form using JSONNET.

The two examples are lga0t (a test site) and tyo01 (a synthetic site run from a GCE VM). And, the first format generates the same format as the current mlab-site-info.json files used by mlab-ns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/1)
<!-- Reviewable:end -->
