### PR TITLE
Use base10 suffix for IPv6 addresses

### DIFF
--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -105,7 +105,7 @@
     local v6net = $.network.ipv6.prefix;
     local v4off = $._v4_net_offset($.network.ipv4.prefix);
     if v6net == null then '' else
-      '%s%x' % [std.split(v6net, '/')[0], v4off + i]
+      '%s%d' % [std.split(v6net, '/')[0], v4off + i]
   ),
   // gateway6
   gateway6():: (

--- a/lib/site_test.jsonnet
+++ b/lib/site_test.jsonnet
@@ -154,7 +154,7 @@ test.suite({
     ],
     expect: [
       '',
-      '2001:1900:2100:2d::56',
+      '2001:1900:2100:2d::86',
     ],
   },
   test_machine_v6_record: {
@@ -187,7 +187,7 @@ test.suite({
       v4Site.experiment(1, { index: 1, name: 'fake.exp' }).v6.ip,
     ],
     expect: [
-      '2001:1900:2100:2d::57',  // 0x57 == 87
+      '2001:1900:2100:2d::87',
       'fake.exp.mlab2.mck0t',
       'fake.exp.mlab2v6.mck0t',
       '',


### PR DESCRIPTION
Complementary to https://github.com/m-lab/index2ip/pull/14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/7)
<!-- Reviewable:end -->
