### PR TITLE
Add automated generation for siteinfo API and CloudBuild deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build image.
+FROM golang:1.12-alpine as jsonnet-build
+RUN apk add --no-cache git
+RUN go get -v github.com/google/go-jsonnet/cmd/jsonnet
+
+# Final image.
+FROM alpine:3.9
+COPY --from=jsonnet-build /go/bin/jsonnet /bin
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN apk add openjdk8 bash make bind-tools
+RUN wget -O /usr/bin/sjsonnet.jar https://github.com/lihaoyi/sjsonnet/releases/download/0.1.3/sjsonnet.jar
+RUN chmod 755 /usr/bin/sjsonnet.jar
+WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,48 @@ LATEST=$(shell date +%Y%m%d00 )
 CURRENT=$(shell dig @dns.measurementlab.net soa measurementlab.net \
       | grep SOA \
       | awk '{print $$7}' )
+OUTDIR=output
+ARCHDIR:=$(shell date +%Y/%m/%d/%H:%M:%S )
+SJSONNET_JAR=/usr/bin/sjsonnet.jar
+# NOTE: It's possible to execute the sjsonnet.jar directly, however that uses
+# the default heap size of 64M which is not always enough for our large outputs.
+# So, run sjsonnet the hard way and provide maximum heap.
+SJSONNET=java -Xmx2G -cp $(SJSONNET_JAR) sjsonnet.SjsonnetMain
 
-all: $(ALL)
+.PHONY: output
+
+all: output $(ALL)
+	mkdir -p $(OUTDIR)/configs/sites/$(ARCHDIR)
+	cp $(OUTDIR)/v1/sites/* $(OUTDIR)/configs/sites/$(ARCHDIR)/
+	mkdir -p $(OUTDIR)/configs/zones/$(ARCHDIR)
+	cp $(OUTDIR)/v1/zones/* $(OUTDIR)/configs/zones/$(ARCHDIR)/
 
 test: $(TESTS)
+
+output:
+	mkdir -p $(OUTDIR)/v1/zones
+	mkdir -p $(OUTDIR)/v1/sites
 
 clean:
 	rm -f *.json *.zone
 
 %.json: formats/%.json.jsonnet $(DEPS)
-	time jsonnet -J . $< > $@
+	time $(SJSONNET) -J . $< > $(OUTDIR)/v1/sites/$@
 
 %_test: %_test.jsonnet $(DEPS)
-	time jsonnet -J . -J jsonnetunit $<
+	time $(SJSONNET) -J . -J jsonnetunit $<
 
+# NOTE: sjsonnet.jar does not support the --string option. And, jsonnet alone
+# takes over 6min to process the zone file. So, this two step operation saves
+# _considerable_ time.
 %.zone: formats/%.zone.jsonnet $(DEPS)
-	time jsonnet -J . --string --ext-str latest=$(strip $(LATEST)) \
-		--ext-str serial=$(strip $(CURRENT)) \
-		$< > $@
+	time $(SJSONNET) -J . \
+	  --ext-str latest=$(strip $(LATEST)) \
+		--ext-str serial=$(strip $(CURRENT)) $< \
+		| jsonnet --string - > $(OUTDIR)/v1/zones/$@
+	rm -f $(OUTDIR)/v1/zones/$@.tmp
 
+# NOTE: this target only works with the C++ implementation of jsonnet.
 fmt:
 	@find . -name '*.jsonnet' -print0 | while read -d $$'\0' f; do \
 	  jsonnet fmt --indent 2 --max-blank-lines 2 --sort-imports \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,34 @@
+############################################################################
+# BUILD ARTIFACTS
+############################################################################
+
+steps:
+# Create the sjsonnet container for later steps.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'jsonnet-env', '.'
+  ]
+
+# Generate jsonnet files.
+- name: jsonnet-env
+  args: [
+    'make'
+  ]
+
+############################################################################
+# DEPLOY ARTIFACTS
+############################################################################
+
+# Publish new data.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
+    'cp', '-r', '/workspace/output/v1/*', 'gs://siteinfo-$PROJECT_ID/v1/'
+  ]
+
+# Copy configs to archive.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
+    'cp', '-r', '/workspace/output/configs/*', 'gs://siteinfo-$PROJECT_ID/configs/'
+  ]

--- a/formats/measurement-lab.org.zone.jsonnet
+++ b/formats/measurement-lab.org.zone.jsonnet
@@ -2,8 +2,8 @@ local experiments = import 'experiments.jsonnet';
 local sites = import 'sites.jsonnet';
 local flatten(record) = std.strReplace(record, '.', '-');
 local serial(current, latest) = (
-  if current == "" || latest == "" then
-    error "ERROR: given serial and latest must not be empty!"
+  if current == '' || latest == '' then
+    error 'ERROR: given serial and latest must not be empty!'
   else
     if current < latest then
       latest

--- a/formats/sites.json.jsonnet
+++ b/formats/sites.json.jsonnet
@@ -1,0 +1,21 @@
+local experiments = import 'experiments.jsonnet';
+local sites = import 'sites.jsonnet';
+[
+  site {
+    nodes: [
+      local m = site.machine(mIndex);
+      m {
+        name: m.hostname(),
+        experiments: [
+          local e = site.experiment(mIndex, experiment);
+          e {
+            name: e.hostname(),
+          }
+          for experiment in experiments
+        ],
+      }
+      for mIndex in std.range(1, site.machines.count)
+    ],
+  }
+  for site in sites
+]


### PR DESCRIPTION
This change adds new support for deploying generated siteinfo configs to a GCS bucket using CloudBuild. As well, this change is a precursor to supporting the siteinfo API using a cloud "loadbalancer with GCS bucket backend".

In service of that API, this change creates the following target directories:

* `/v1/sites/` - experiment, node, and site metadata
* `/v1/zones/` - generated DNS zone files & diffs.
* `/configs/`  - archived versions of the above

For example, once the load balancer is configured, the ultimate API resources will look like:

* https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/locations.json
* https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/hostnames.json
* https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/sites.json
* https://siteinfo.mlab-sandbox.measurementlab.net/v1/zones/measurement-lab.org.zone
* https://siteinfo.mlab-sandbox.measurementlab.net/v1/zones/measurement-lab.org.zone.diff

This change also archives generated siteinfo data according to the conventions of "Configs as archival M-Lab data".

The new `formats/sites.json.jsonnet` format replaces the unhelpful `raw-sites.json` and should provide the input data needed to decouple mlabconfig.py from sites.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/8)
<!-- Reviewable:end -->
