### PR TITLE
Add basic support for generating the zone diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ clean:
 		--ext-str serial=$(strip $(CURRENT)) $< \
 		| jsonnet --string - > $(OUTDIR)/v1/zones/$@
 	rm -f $(OUTDIR)/v1/zones/$@.tmp
+	./zonediff.sh $(OUTDIR)/v1/zones
 
 # NOTE: this target only works with the C++ implementation of jsonnet.
 fmt:

--- a/zonediff.sh
+++ b/zonediff.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+OUTPUT=${1:?Please provide output location}
+_=${PROJECT:?Please provide PROJECT name in environment}
+ZONE=measurement-lab.org.zone
+URL=https://siteinfo.${PROJECT}.measurementlab.net/v1/zones/${ZONE}
+diff -Ndur \
+  <( curl --silent ${URL} ) \
+  ${OUTPUT}/${ZONE} > ${OUTPUT}/${ZONE}.diff || :


### PR DESCRIPTION
This change adds basic support for generating the measurement-lab.org.zone diff for the current configs relative to the version currently published in the siteinfo api.

There is one limitation of this approach: it is not guaranteed that the version currently read from siteinfo API is actually the version deployed to dns.measurementlab.net -- to guarantee the diff we would want to source the current zone from dns.measurementlab.net or perhaps only source the version at mlab-oti.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/10)
<!-- Reviewable:end -->
