### PR TITLE
Add rsync modules to experiments.jsonnet

### DIFF
--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -11,6 +11,12 @@ local default = {
     name: 'ndt.iupui',
     flat_hostname: true,
     cloud_enabled: true,
+    rsync_modules: ['ndt'],
+  },
+  default {
+    index: 3,
+    name: 'npad.iupui',
+    rsync_modules: ['sidestream', 'npad', 'paris-traceroute'],
   },
   default {
     index: 5,
@@ -33,6 +39,7 @@ local default = {
   default {
     index: 10,
     name: 'neubot.mlab',
+    rsync_modules: ['neubot'],
   },
   default {
     index: 11,
@@ -41,5 +48,6 @@ local default = {
   default {
     index: 12,
     name: 'utility.mlab',
+    rsync_modules: ['utilization', 'switch'],
   },
 ]

--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -3,6 +3,7 @@ local default = {
   ipv6_enabled: true,
   flat_hostname: false,
   cloud_enabled: false,
+  rsync_modules: [],
 };
 
 [


### PR DESCRIPTION
This change adds the rsync modules to preserve the ability to generate some configs for rsync during the platform migration to k8s. Once that migration is complete we can eliminate the rsync module fields (which have no meaning on the new platform).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/15)
<!-- Reviewable:end -->
