### PR TITLE
Add uplink_speed to site locations

### DIFF
--- a/formats/sites/locations.json.jsonnet
+++ b/formats/sites/locations.json.jsonnet
@@ -12,6 +12,7 @@ local sites = import 'sites.jsonnet';
     longitude: location.longitude,
     latitude: location.latitude,
     roundrobin: site.loadbalancer.roundrobin,
+    uplink_speed: site.transit.uplink,
   }
   for site in sites
 ]


### PR DESCRIPTION
This change adds the `uplink_speed` key to the siteinfo locations.json format.

Part of https://github.com/m-lab/dev-tracker/issues/365

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/18)
<!-- Reviewable:end -->
