### PR TITLE
Add OONI experiment back

### DIFF
--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -29,6 +29,12 @@ local default = {
     ipv6_enabled: false,
   },
   default {
+    index: 7,
+    name: "ooni.mlab",
+    ipv6_enabled: false,
+    rsync_modules: ['ooni'],
+  },
+  default {
     index: 8,
     name: 'ispmon.samknows',
   },


### PR DESCRIPTION
This PR adds back the OONI experiment to `experiments.json`.

Migrating the DNS configuration to siteinfo had the unintended side effect of removing the DNS entry for this experiment. Chatting with the OONI folks, I've discovered they might still be using it somewhere. Also, it's making scraper fail on the legacy platform since it tries to rsync `mlab.ooni.<node>.<site>.measurement-lab.org`. This PR + redeploying DNS zones should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/24)
<!-- Reviewable:end -->
