### PR TITLE
Add DNS record for the router (r1.<site>)

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -13,8 +13,9 @@ local serial(current, latest) = (
 
 local records = std.flattenArrays([
   // Routers & switches
+  local s1 = site.Switch();
+  local r1 = site.Router();
   [
-    local s1 = site.Switch(), r1 = site.Router();
     { record: s1.Record(), ipv4: s1.v4.ip },
     { record: r1.Record(), ipv4: r1.v4.ip },
   ]
@@ -78,7 +79,7 @@ std.lines([
     @       IN      A       128.112.139.90
     @       IN      MX 0    mail.planet-lab.org.
     *       IN      MX 0    mail.planet-lab.org.
-  ||| % serial(std.extVar('serial'), std.extVar('latest')),
+  ||| % serial(1, 2),
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]
   for row in records

--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -14,8 +14,7 @@ local serial(current, latest) = (
 local records = std.flattenArrays([
   // Routers & switches
   [
-    local s1 = site.Switch();
-    local r1 = site.Router();
+    local s1 = site.Switch(), r1 = site.Router();
     { record: s1.Record(), ipv4: s1.v4.ip },
     { record: r1.Record(), ipv4: r1.v4.ip },
   ]

--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -79,7 +79,7 @@ std.lines([
     @       IN      A       128.112.139.90
     @       IN      MX 0    mail.planet-lab.org.
     *       IN      MX 0    mail.planet-lab.org.
-  ||| % serial(1, 2),
+  ||| % serial(std.extVar('serial'), std.extVar('latest')),
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]
   for row in records

--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -15,7 +15,9 @@ local records = std.flattenArrays([
   // Routers & switches
   [
     local s1 = site.Switch();
+    local r1 = site.Router();
     { record: s1.Record(), ipv4: s1.v4.ip },
+    { record: r1.Record(), ipv4: r1.v4.ip },
   ]
   for site in sites
   if site.annotations.type == 'physical'

--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -13,10 +13,10 @@ local serial(current, latest) = (
 
 local records = std.flattenArrays([
   // Routers & switches
-  local s1 = site.Switch();
-  local r1 = site.Router();
   [
+    local s1 = site.Switch();
     { record: s1.Record(), ipv4: s1.v4.ip },
+    local r1 = site.Router();
     { record: r1.Record(), ipv4: r1.v4.ip },
   ]
   for site in sites

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -13,7 +13,7 @@
       ip: $.Index4(1),
     },
     Record():: 'r1.%s' % $.name,
-    Hostname():: '$s.measurement-lab.org' % self.Record(),
+    Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
   // DRAC returns a network spec for the drac attached to machine index m.
   DRAC(m):: {

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -7,7 +7,7 @@
     Record():: 's1.%s' % $.name,
     Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
-  // Router returns a network spec for the site router.
+  // Router returns a network spec for the site's upstream router.
   Router():: {
     v4: {
       ip: $.Index4(1),

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -7,6 +7,13 @@
     Record():: 's1.%s' % $.name,
     Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
+  Router():: {
+    v4: {
+      ip: $.Index4(1),
+    },
+    Record():: 'r1.%s' % $.name,
+    Hostname():: '$s.measurement-lab.org' % self.Record(),
+  },
   // DRAC returns a network spec for the drac attached to machine index m.
   DRAC(m):: {
     v4: {

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -7,6 +7,7 @@
     Record():: 's1.%s' % $.name,
     Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
+  // Router returns a network spec for the site router.
   Router():: {
     v4: {
       ip: $.Index4(1),


### PR DESCRIPTION
This PR adds a DNS record for `r1.<site>`, which is needed by the `configure_drac.py` script to find what's the default gateway to set on a DRAC.

Here's the diff generated by this change (at least until it's overwritten by another build):
https://siteinfo.mlab-sandbox.measurementlab.net/v1/zones/measurement-lab.org.zone.diff

Closes https://github.com/m-lab/siteinfo/issues/28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/29)
<!-- Reviewable:end -->
