### PR TITLE
Update uplink and switch make for MNL01

### DIFF
--- a/sites/mnl01.jsonnet
+++ b/sites/mnl01.jsonnet
@@ -15,14 +15,11 @@ sitesDefault {
   },
   transit+: {
     provider: 'Department of Science and Technology',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS9821',
   },
   switch+: {
     flow_control: 'no',
-    uplink_port: '48',
-    make: 'hp',
-    model: 'procurve',
   },
   location+: {
     continent_code: 'AS',


### PR DESCRIPTION
This PR updates the switch details for MNL01. This site's upstream has been recently upgraded to 10g and the switch is a Juniper now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/31)
<!-- Reviewable:end -->
