### PR TITLE
Revert "Add DNS record for the router (r1.<site>)."

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -16,8 +16,6 @@ local records = std.flattenArrays([
   [
     local s1 = site.Switch();
     { record: s1.Record(), ipv4: s1.v4.ip },
-    local r1 = site.Router();
-    { record: r1.Record(), ipv4: r1.v4.ip },
   ]
   for site in sites
   if site.annotations.type == 'physical'

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -7,14 +7,6 @@
     Record():: 's1.%s' % $.name,
     Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
-  // Router returns a network spec for the site's upstream router.
-  Router():: {
-    v4: {
-      ip: $.Index4(1),
-    },
-    Record():: 'r1.%s' % $.name,
-    Hostname():: '%s.measurement-lab.org' % self.Record(),
-  },
   // DRAC returns a network spec for the drac attached to machine index m.
   DRAC(m):: {
     v4: {


### PR DESCRIPTION
This removes the `r1.<site>` DNS entry generation since the only use case for it has already been handled differently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/32)
<!-- Reviewable:end -->
