### PR TITLE
Add 'd' as decoration to support BMCs

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -181,7 +181,7 @@ def parse_flags():
         dest='decoration',
         default='',
         choices=['', 'v4', 'v6', 'd'],
-        help='Protocol decoration for Prom targets (e.g, mlab1v4.abc01).')
+        help='Decoration for Prom targets (e.g, mlab1v4.abc01).')
     parser.add_option(
         '',
         '--select',

--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -180,7 +180,7 @@ def parse_flags():
         '--decoration',
         dest='decoration',
         default='',
-        choices=['', 'v4', 'v6'],
+        choices=['', 'v4', 'v6', 'd'],
         help='Protocol decoration for Prom targets (e.g, mlab1v4.abc01).')
     parser.add_option(
         '',


### PR DESCRIPTION
This PR adds `d` as a possible decoration in mlabconfig.py. This allows to leverage the existing code to generate targets where `hostname` is `<node>d.<site>.measurement-lab.org`.

The rationale behind it is that then we can call `mlabconfig.py` with a `--template` such as `https://<user>:<pass>@reboot.<project>.measurementlab.net/v1/e2e?target={{hostname}}` with the decorated `hostname` to generate a target for each BMC on the M-Lab infrastructure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/34)
<!-- Reviewable:end -->
