### PR TITLE
Add initial sitegeo output

### DIFF
--- a/formats/adhoc/sitegeo.json.jsonnet
+++ b/formats/adhoc/sitegeo.json.jsonnet
@@ -1,0 +1,25 @@
+local sites = import 'sites.jsonnet';
+{
+  type: "FeatureCollection",
+  features: [
+    {
+      local location = site.location,
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [location.longitude, location.latitude],
+      },
+      properties: {
+        name: site.name,
+        metro: location.metro,
+        city: location.city,
+        provider: site.transit.provider,
+        uplink: site.transit.uplink,
+        asn: site.transit.asn,
+        ipv4_prefix: site.network.ipv4.prefix,
+        ipv6_prefix: site.network.ipv6.prefix,
+      }
+    }
+    for site in sites
+  ]
+}

--- a/sites/chs0c.jsonnet
+++ b/sites/chs0c.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/iad0c.jsonnet
+++ b/sites/iad0c.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/lax0c.jsonnet
+++ b/sites/lax0c.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/oma0c.jsonnet
+++ b/sites/oma0c.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/pdx0c.jsonnet
+++ b/sites/pdx0c.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/tyo01.jsonnet
+++ b/sites/tyo01.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/tyo02.jsonnet
+++ b/sites/tyo02.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },

--- a/sites/tyo03.jsonnet
+++ b/sites/tyo03.jsonnet
@@ -17,6 +17,7 @@ sitesDefault {
     },
   },
   transit+: {
+    asn: 'AS15169',
     provider: 'Google',
     uplink: '1g',
   },


### PR DESCRIPTION
This change adds a new output format for site GeoJSON to feed into a new "site location" map.

The format is placed in v1/adhoc for now while we experiment with the format. If the format is useful, we should move it to `v1/sites/geo.json`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/36)
<!-- Reviewable:end -->
