### PR TITLE
Add decorated flat hostnames when specified

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -43,8 +43,12 @@ local records = std.flattenArrays([
     { record: e.Record(), ipv4: e.v4.ip, ipv6: e.v6.ip },
     { record: e.Record('v4'), ipv4: e.v4.ip },
     { record: e.Record('v6'), ipv6: e.v6.ip },
-    if e.flat_hostname == true then
-      { record: flatten(e.Record()), ipv4: e.v4.ip, ipv6: e.v6.ip },
+  ] + if e.flat_hostname == true then [
+    { record: flatten(e.Record()), ipv4: e.v4.ip, ipv6: e.v6.ip },
+    { record: flatten(e.Record('v4')), ipv4: e.v4.ip },
+    { record: flatten(e.Record('v6')), ipv6: e.v6.ip },
+  ] else [
+    // do nothing for flat_hostname == false.
   ]
   for site in sites
   for mIndex in std.range(1, site.machines.count)


### PR DESCRIPTION
Some blackbox exporter monitoring targets use the flat-decorated hostnames and require that we include these in the DNS zone. This change adds them back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/40)
<!-- Reviewable:end -->
