### PR TITLE
Adds already-migrated sites and machines to upgrade.json.

### DIFF
--- a/formats/adhoc/upgrade.json.jsonnet
+++ b/formats/adhoc/upgrade.json.jsonnet
@@ -1,24 +1,53 @@
 local experiments = import 'experiments.jsonnet';
 local sites = import 'sites.jsonnet';
+
+local migrated = {
+  "den06": std.range(1, 4),
+  "del01": std.range(1, 4),
+  "vie01": [1],
+};
+
 // NOTE: Add a nonce to the hostname so that md5 includes mlab3.lga03 and
 // mlab3.lax02 - already upgraded during 10th anniversary.
 local hashHostKey = function(x) std.substr(std.md5(x.hostname + 'nonce0'), 30, 2);
-std.flattenArrays([
-  local s = std.sort([
-    {
-      local m = site.Machine(mIndex),
-      hostname: m.Hostname(),
-      ipv4: m.v4.ip,
-      ipv6: m.v6.ip,
-    }
-    // For now, only consier mlab2s and mlab3s.
-    for mIndex in std.range(2, 3)
-  ], hashHostKey);
-  [
-    s[0],
-    // Once we wish to include mlab1s, report top 2 sites:
-    // s[1],
-  ]
-  for site in sites
-  if (site.annotations.type == 'physical')
-])
+
+std.sort(
+  std.flattenArrays([
+    local s = std.sort([
+      {
+        local m = site.Machine(mIndex),
+        hostname: m.Hostname(),
+        ipv4: m.v4.ip,
+        ipv6: m.v6.ip,
+      }
+      // For now, only consier mlab2s and mlab3s.
+      for mIndex in std.range(2, 3)
+    ], hashHostKey);
+    [
+      s[0],
+      // Once we wish to include mlab1s, report top 2 sites:
+      // s[1],
+    ]
+    for site in sites
+    if (site.annotations.type == 'physical')
+    if !std.objectHas(migrated, site.name)
+  ])
+
+  +
+
+  std.flattenArrays([
+    local s = [
+      {
+        local m = site.Machine(mIndex),
+        hostname: m.Hostname(),
+        ipv4: m.v4.ip,
+        ipv6: m.v6.ip,
+      }
+      for mIndex in migrated[site.name]
+    ];
+    s
+    for site in sites
+    if std.objectHas(migrated, site.name)
+  ])
+, function(x) x.hostname)
+


### PR DESCRIPTION
We have a few sites and machines that are already migrated to k8s, and thus should be added upgrade.json. This PR adds a local variable that lists these sites, and specifies which machine have already been migrated.

NOTE: The sort order of the output may has changed somewhat. The sort will now be by node, then by site, which will group mlab1s, mlab2s, etc. (i.e., nodes at a site will not appear next to one another in the list).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/47)
<!-- Reviewable:end -->
