### PR TITLE
Apply CORS settings to the siteinfo bucket

### DIFF
--- a/cors-settings.json
+++ b/cors-settings.json
@@ -1,0 +1,6 @@
+[
+    {
+      "origin": ["*"],
+      "method": ["GET", "POST", "PUT", "HEAD", "PATCH", "DELETE", "OPTIONS"]
+    }
+]

--- a/cors-settings.json.template
+++ b/cors-settings.json.template
@@ -1,14 +1,8 @@
 [
     {
-      "origin": ["http://website.{{PROJECT}}.measurementlab.net"],
+      "origin": ["*"],
       "responseHeader": ["Content-Type"],
-      "method": ["GET"],
-      "maxAgeSeconds": 3600
-    },
-    {
-      "origin": ["https://www.measurementlab.net"],
-      "responseHeader": ["Content-Type"],
-      "method": ["GET"],
+      "method": ["GET", "POST", "PUT", "HEAD", "PATCH", "DELETE", "OPTIONS"],
       "maxAgeSeconds": 3600
     }
 ]

--- a/cors-settings.json.template
+++ b/cors-settings.json.template
@@ -1,0 +1,14 @@
+[
+    {
+      "origin": ["http://website.{{PROJECT}}.measurementlab.net"],
+      "responseHeader": ["Content-Type"],
+      "method": ["GET"],
+      "maxAgeSeconds": 3600
+    },
+    {
+      "origin": ["https://www.measurementlab.net"],
+      "responseHeader": ["Content-Type"],
+      "method": ["GET"],
+      "maxAgeSeconds": 3600
+    }
+]

--- a/cors-settings.json.template
+++ b/cors-settings.json.template
@@ -1,8 +1,0 @@
-[
-    {
-      "origin": ["*"],
-      "responseHeader": ["Content-Type"],
-      "method": ["GET", "POST", "PUT", "HEAD", "PATCH", "DELETE", "OPTIONS"],
-      "maxAgeSeconds": 3600
-    }
-]

--- a/create_siteinfo_api.sh
+++ b/create_siteinfo_api.sh
@@ -154,4 +154,4 @@ fi
 # Apply CORS settings to the GCS bucket.
 sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
   cors-settings.json
-gsutil cors set cors-settings.json gs://siteinfo-${PROJECT}
+gsutil cors set cors-settings.json gs://${siteinfo_bucket}

--- a/create_siteinfo_api.sh
+++ b/create_siteinfo_api.sh
@@ -18,6 +18,11 @@ if ! gsutil acl get "gs://${empty_bucket}" &> /dev/null ; then
   gsutil defacl set public-read "gs://${empty_bucket}"
 fi
 
+# Apply CORS settings to the siteinfo bucket.
+sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
+  cors-settings.json
+gsutil cors set cors-settings.json gs://${siteinfo_bucket}
+
 # Lookup or create loadbalancer IP.
 lb_ip=$(
   gcloud --project ${PROJECT} compute addresses describe \
@@ -150,8 +155,3 @@ if [[ -z "${forwarder_name}" ]] ; then
     --target-https-proxy ${proxy_name} \
     --ports 443
 fi
-
-# Apply CORS settings to the GCS bucket.
-sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
-  cors-settings.json
-gsutil cors set cors-settings.json gs://${siteinfo_bucket}

--- a/create_siteinfo_api.sh
+++ b/create_siteinfo_api.sh
@@ -151,7 +151,7 @@ if [[ -z "${forwarder_name}" ]] ; then
     --ports 443
 fi
 
-# Make sure CORS settings are applied to the GCS bucket.
+# Apply CORS settings to the GCS bucket.
 sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
   cors-settings.json
-gsutil cors set ~/cors-settings.json gs://siteinfo-${PROJECT}
+gsutil cors set cors-settings.json gs://siteinfo-${PROJECT}

--- a/create_siteinfo_api.sh
+++ b/create_siteinfo_api.sh
@@ -150,3 +150,8 @@ if [[ -z "${forwarder_name}" ]] ; then
     --target-https-proxy ${proxy_name} \
     --ports 443
 fi
+
+# Make sure CORS settings are applied to the GCS bucket.
+sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
+  cors-settings.json
+gsutil cors set ~/cors-settings.json gs://siteinfo-${PROJECT}

--- a/create_siteinfo_api.sh
+++ b/create_siteinfo_api.sh
@@ -19,8 +19,6 @@ if ! gsutil acl get "gs://${empty_bucket}" &> /dev/null ; then
 fi
 
 # Apply CORS settings to the siteinfo bucket.
-sed -e 's/{{PROJECT}}/${PROJECT}/g' cors-settings.json.template > \
-  cors-settings.json
 gsutil cors set cors-settings.json gs://${siteinfo_bucket}
 
 # Lookup or create loadbalancer IP.


### PR DESCRIPTION
This PR adds the CORS configuration via `gsutil` to `create_siteinfo_api.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/52)
<!-- Reviewable:end -->
