### PR TITLE
Add IPv6 addresses for ARN06 and FRA05

### DIFF
--- a/sites/arn06.jsonnet
+++ b/sites/arn06.jsonnet
@@ -10,7 +10,7 @@ sitesDefault {
       prefix: '193.142.125.64/26',
     },
     ipv6+: {
-      prefix: null,
+      prefix: '2a01:3e0:1b01:2::/64',
     },
   },
   transit+: {

--- a/sites/fra05.jsonnet
+++ b/sites/fra05.jsonnet
@@ -10,7 +10,7 @@ sitesDefault {
       prefix: '193.142.125.0/26',
     },
     ipv6+: {
-      prefix: null,
+      prefix: '2a01:3e0:ff20:401::/64',
     },
   },
   transit+: {


### PR DESCRIPTION
This PR adds the IPv6 addresses for ARN06 and FRA05.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/54)
<!-- Reviewable:end -->
