### PR TITLE
Creates 'flattened' hostnames for neubot.

### DIFF
--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -45,6 +45,7 @@ local default = {
   },
   default {
     index: 10,
+    flat_hostname: true,
     name: 'neubot.mlab',
     rsync_modules: ['neubot'],
   },


### PR DESCRIPTION
Neubot would like to use the `*.measurement-lab.org` wildcard certificate too, so it will need "flattened", in addition to NDT.