### PR TITLE
Adds a new configuration to the default site config for 'rstp' 

### DIFF
--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -34,6 +34,7 @@ site {
     flow_control: 'yes',
     make: 'juniper',
     model: 'qfx5100',
+    rstp: 'yes',
     uplink_port: (
       if $.transit.uplink == '10g' then
         'xe-0/0/45'

--- a/sites/bcn01.jsonnet
+++ b/sites/bcn01.jsonnet
@@ -20,6 +20,7 @@ sitesDefault {
   },
   switch+: {
     flow_control: 'no',
+    rstp: 'no',
   },
   location+: {
     continent_code: 'EU',


### PR DESCRIPTION
RSTP = Rapid Spanning Tree Protocol. The default value will be 'yes'. It will be disabled for BCN01.

This is necessary because we have one site, BCN01, which needs to have RSTP disabled. From the site host:

> That port is connected to switch in the DMZ at CATNIX.  In all IXP's, the customer are not allowed to be visible as L2 bridges. This means that they should not speak STP (spanning tree) or any other (proprietary) L2 specific protocol.
>
> Could you disable STP in that interface?

Adding this new setting to the default site template allows us to not have to exception handle for this setting. `genconfig.py` in the switch-config repo will need to take this new setting into account, which will be a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/61)
<!-- Reviewable:end -->
