### PR TITLE
Updates all U.S. Tata sites to 10g

### DIFF
--- a/sites/atl03.jsonnet
+++ b/sites/atl03.jsonnet
@@ -15,11 +15,8 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
-  },
-  switch+: {
-    auto_negotiation: 'no',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/dfw02.jsonnet
+++ b/sites/dfw02.jsonnet
@@ -15,11 +15,8 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
-  },
-  switch+: {
-    auto_negotiation: 'no',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/iad03.jsonnet
+++ b/sites/iad03.jsonnet
@@ -15,11 +15,8 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
-  },
-  switch+: {
-    auto_negotiation: 'no',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/lax02.jsonnet
+++ b/sites/lax02.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
   },
   location+: {

--- a/sites/lga03.jsonnet
+++ b/sites/lga03.jsonnet
@@ -15,11 +15,8 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
-  },
-  switch+: {
-    auto_negotiation: 'no',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/mia03.jsonnet
+++ b/sites/mia03.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
   },
   location+: {

--- a/sites/nuq04.jsonnet
+++ b/sites/nuq04.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
   },
   location+: {

--- a/sites/ord03.jsonnet
+++ b/sites/ord03.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'TATA COMMUNICATIONS (AMERICA) INC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS6453',
   },
   location+: {


### PR DESCRIPTION
Well, all but SEA02, which was already correct. These circuits were upgraded a year ago, but never update in our docs, apparently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/64)
<!-- Reviewable:end -->
