### PR TITLE
Add DRAC entries to sites.json

### DIFF
--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -16,6 +16,14 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
+    dracs: [
+      local d = site.DRAC(mIndex);
+      d {
+        hostname: d.Hostname(),
+        v4: d.v4,
+      }
+      for mIndex in std.range(1, site.machines.count)
+    ],
   }
   for site in sites
 ]

--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -4,8 +4,12 @@ local sites = import 'sites.jsonnet';
   site {
     nodes: [
       local m = site.Machine(mIndex);
+      local d = site.DRAC(mIndex);
       m {
         hostname: m.Hostname(),
+        drac: d + {
+          hostname: d.Hostname()
+        },
         experiments: [
           local e = site.Experiment(mIndex, experiment);
           e {
@@ -16,14 +20,7 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
-    dracs: [
-      local d = site.DRAC(mIndex);
-      d {
-        hostname: d.Hostname(),
-        v4: d.v4,
-      }
-      for mIndex in std.range(1, site.machines.count)
-    ],
+
   }
   for site in sites
 ]

--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -20,7 +20,6 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
-
   }
   for site in sites
 ]


### PR DESCRIPTION
This PR adds a DRAC entry under each node in `sites.json`. It's also the first step to add the DRAC configuration to stage1 ISOs.

Closes https://github.com/m-lab/siteinfo/issues/67.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/68)
<!-- Reviewable:end -->
