### PR TITLE
Read DRAC's IPv4 from siteinfo

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -283,6 +283,8 @@ def export_mlab_server_network_config(output, sites, name_tmpl, input_tmpl,
             i.update({'ipv6_' + k: node['v6'][k] for k in node['v6']})
             i['ipv6_enabled'] = 'true' if node['v6']['ip'] else 'false'
             i['ipv6_address'] = i['ipv6_ip']
+            # Add DRAC IPv4 settings.
+            i['drac_ipv4_address'] = node['drac']['v4']['ip']
             # Add extra provided labels.
             i.update(labels)
             filename = output_name.safe_substitute(i)

--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -16,6 +16,14 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
+    dracs: [
+      local d = site.DRAC(mIndex);
+      d {
+        hostname: d.Hostname(),
+        v4: d.v4,
+      }
+      for mIndex in std.range(1, site.machines.count)
+    ],
   }
   for site in sites
 ]

--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -4,8 +4,12 @@ local sites = import 'sites.jsonnet';
   site {
     nodes: [
       local m = site.Machine(mIndex);
+      local d = site.DRAC(mIndex);
       m {
         hostname: m.Hostname(),
+        drac: d + {
+          hostname: d.Hostname()
+        },
         experiments: [
           local e = site.Experiment(mIndex, experiment);
           e {
@@ -16,14 +20,7 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
-    dracs: [
-      local d = site.DRAC(mIndex);
-      d {
-        hostname: d.Hostname(),
-        v4: d.v4,
-      }
-      for mIndex in std.range(1, site.machines.count)
-    ],
+
   }
   for site in sites
 ]

--- a/formats/sites/sites.json.jsonnet
+++ b/formats/sites/sites.json.jsonnet
@@ -20,7 +20,6 @@ local sites = import 'sites.jsonnet';
       }
       for mIndex in std.range(1, site.machines.count)
     ],
-
   }
   for site in sites
 ]


### PR DESCRIPTION
This PR changes `export_mlab_server_network_config` to also read the DRAC's IPv4 address from `sites.json`. This is needed so that `drac_ipv4_address` can be replaced in an epoxy-images configuration template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/70)
<!-- Reviewable:end -->
