### PR TITLE
Adds missing site ARN06 to the list sites that are already fully migrated to ePoxy/k8s

### DIFF
--- a/formats/adhoc/upgrade-2nd.json.jsonnet
+++ b/formats/adhoc/upgrade-2nd.json.jsonnet
@@ -2,6 +2,7 @@ local experiments = import 'experiments.jsonnet';
 local sites = import 'sites.jsonnet';
 
 local migrated = {
+  "arn06": std.range(1, 4),
   "del01": std.range(1, 4),
   "den06": std.range(1, 4),
   "fra05": std.range(1, 4),

--- a/formats/adhoc/upgrade-3rd.json.jsonnet
+++ b/formats/adhoc/upgrade-3rd.json.jsonnet
@@ -2,6 +2,7 @@ local experiments = import 'experiments.jsonnet';
 local sites = import 'sites.jsonnet';
 
 local migrated = {
+  "arn06": std.range(1, 4),
   "del01": std.range(1, 4),
   "den06": std.range(1, 4),
   "fra05": std.range(1, 4),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/72)
<!-- Reviewable:end -->
