### PR TITLE
Removes MX records for measurement-lab.org 

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -77,10 +77,8 @@ std.lines([
     @       IN      NS      sns-pb.isc.org.
     @       IN      NS      ns-mlab.greenhost.net.
 
-    ; TODO: fix A and MX records appropriately.
-    @       IN      A       128.112.139.90
-    @       IN      MX 0    mail.planet-lab.org.
-    *       IN      MX 0    mail.planet-lab.org.
+    @       IN      A       151.101.1.195
+    @       IN      A       151.101.65.195
   ||| % serial(std.extVar('serial'), std.extVar('latest')),
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]


### PR DESCRIPTION
... and sets origin A records to the same as measurementlab.net.

Currently, the MX records for the measurement-lab.org zone point to a PlanetLab address, which is no longer accurate or correct. Indeed, the domain measurement-lab.org does not handle either incoming or outgoing email at all, so this PR just dispenses with the MX records altogether. There is no need to advertise a mail exchange for a domain which handles no email.

Also, the existing A record for the origin points to some IP belonging to PlanetLab. This PR changes the origin A record(s) to point to the same IPs as our measurementlab.net domain. @critzo, **if this PR is accepted** and merged, would you be able to configure Firebase to redirect any request for measurement-lab.org to measurementlab.net, just like we already do for measurementlab.org?

This PR should resolved issue #5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/74)
<!-- Reviewable:end -->
