### PR TITLE
Adds TXT for Google site verification for Google Firebase

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -79,6 +79,8 @@ std.lines([
 
     @       IN      A       151.101.1.195
     @       IN      A       151.101.65.195
+    ; Google site verification to use this domain in Firebase
+    @       IN      TXT     google-site-verification=YJspItE9L3D8mw76XKHxEGb7x9usph7x_CsqFQbUK28
   ||| % serial(std.extVar('serial'), std.extVar('latest')),
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]


### PR DESCRIPTION
In order for Google Firebase to be able to handle the measurement-lab.org domain, we have to verify the domain with a TXT record. Not ideal, but I wasn't offered another way to verify the domain and this is just a one-time thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/75)
<!-- Reviewable:end -->
