### PR TITLE
Update Level3 sites to 10g

### DIFF
--- a/sites/ams08.jsonnet
+++ b/sites/ams08.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Level 3 Parent, LLC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS3356',
   },
   location+: {

--- a/sites/arn03.jsonnet
+++ b/sites/arn03.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Level 3 Parent, LLC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS3356',
   },
   switch+: {

--- a/sites/mad02.jsonnet
+++ b/sites/mad02.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Level 3 Parent, LLC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS3356',
   },
   switch+: {

--- a/sites/par02.jsonnet
+++ b/sites/par02.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Level 3 Parent, LLC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS3356',
   },
   switch+: {

--- a/sites/prg02.jsonnet
+++ b/sites/prg02.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Level 3 Parent, LLC',
-    uplink: '1g',
+    uplink: '10g',
     asn: 'AS3356',
   },
   switch+: {


### PR DESCRIPTION
This PR updates the `uplink` field on siteinfo for the five Level3 sites that were upgraded this morning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/85)
<!-- Reviewable:end -->
