### PR TITLE
Use alpine:3.9 to build the CPP version of jsonnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git
 RUN go get -v github.com/google/go-jsonnet/cmd/jsonnet
 
 # Build CPP version of jsonnet.
-FROM alpine:latest AS jsonnet-cpp-builder
+FROM alpine:3.9 AS jsonnet-cpp-builder
 RUN apk -U add build-base
 WORKDIR /opt
 RUN wget https://github.com/google/jsonnet/archive/v0.13.0.tar.gz


### PR DESCRIPTION
Builds have started failing with:
```
Step #1: Error relocating /usr/bin/jsonnet: _ZNSt7__cxx1118basic_stringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found
```

I think there has been a incompatible ABI change between `alpine:latest` (the version we use to build) and `alpine:3.9`. Using a tagged version of Alpine for both building and running seems the safest option to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/86)
<!-- Reviewable:end -->
