### PR TITLE
Removes the IPv6 prefix for DEL02, since they were unable to provide us with a /64

### DIFF
--- a/sites/del02.jsonnet
+++ b/sites/del02.jsonnet
@@ -10,7 +10,7 @@ sitesDefault {
       prefix: '61.246.223.0/26',
     },
     ipv6+: {
-      prefix: '2404:a800:1000:23::/64',
+      prefix: null,
     },
   },
   transit+: {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/87)
<!-- Reviewable:end -->
