### PR TITLE
Default flow_control to 'no' and update auto_negotiation where needed.

### DIFF
--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -31,7 +31,7 @@ site {
   },
   switch: {
     auto_negotiation: 'yes',
-    flow_control: 'yes',
+    flow_control: 'no',
     make: 'juniper',
     model: 'qfx5100',
     rstp: 'yes',

--- a/sites/ams03.jsonnet
+++ b/sites/ams03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'NL',

--- a/sites/ams04.jsonnet
+++ b/sites/ams04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'NL',

--- a/sites/ams05.jsonnet
+++ b/sites/ams05.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'NL',

--- a/sites/arn02.jsonnet
+++ b/sites/arn02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'SE',

--- a/sites/arn03.jsonnet
+++ b/sites/arn03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'SE',

--- a/sites/arn04.jsonnet
+++ b/sites/arn04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'SE',

--- a/sites/arn05.jsonnet
+++ b/sites/arn05.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'SE',

--- a/sites/bcn01.jsonnet
+++ b/sites/bcn01.jsonnet
@@ -19,7 +19,6 @@ sitesDefault {
     asn: 'AS49638',
   },
   switch+: {
-    flow_control: 'no',
     rstp: 'no',
   },
   location+: {

--- a/sites/bom02.jsonnet
+++ b/sites/bom02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS4755',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'AS',
     country_code: 'IN',

--- a/sites/bru01.jsonnet
+++ b/sites/bru01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'BE',

--- a/sites/bru02.jsonnet
+++ b/sites/bru02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'BE',

--- a/sites/bru03.jsonnet
+++ b/sites/bru03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'BE',

--- a/sites/bru04.jsonnet
+++ b/sites/bru04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'BE',

--- a/sites/dfw07.jsonnet
+++ b/sites/dfw07.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'NA',
     country_code: 'US',

--- a/sites/dub01.jsonnet
+++ b/sites/dub01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1213',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'IE',

--- a/sites/fln01.jsonnet
+++ b/sites/fln01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS11242',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'SA',
     country_code: 'BR',

--- a/sites/fra01.jsonnet
+++ b/sites/fra01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'DE',

--- a/sites/fra02.jsonnet
+++ b/sites/fra02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'DE',

--- a/sites/fra03.jsonnet
+++ b/sites/fra03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'DE',

--- a/sites/fra04.jsonnet
+++ b/sites/fra04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'DE',

--- a/sites/gru01.jsonnet
+++ b/sites/gru01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3549',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'SA',
     country_code: 'BR',

--- a/sites/gru02.jsonnet
+++ b/sites/gru02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS262589',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'SA',
     country_code: 'BR',

--- a/sites/gru03.jsonnet
+++ b/sites/gru03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS6762',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'SA',
     country_code: 'BR',

--- a/sites/gru04.jsonnet
+++ b/sites/gru04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS12956',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'SA',
     country_code: 'BR',

--- a/sites/hnd02.jsonnet
+++ b/sites/hnd02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS2518',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'AS',
     country_code: 'JP',

--- a/sites/hnd03.jsonnet
+++ b/sites/hnd03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS2516',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'AS',
     country_code: 'JP',

--- a/sites/iad06.jsonnet
+++ b/sites/iad06.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'NA',
     country_code: 'US',

--- a/sites/lga0t.jsonnet
+++ b/sites/lga0t.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'NA',
     country_code: 'US',

--- a/sites/lhr02.jsonnet
+++ b/sites/lhr02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'GB',

--- a/sites/lhr03.jsonnet
+++ b/sites/lhr03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'GB',

--- a/sites/lis02.jsonnet
+++ b/sites/lis02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'PT',

--- a/sites/mad02.jsonnet
+++ b/sites/mad02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'ES',

--- a/sites/mad03.jsonnet
+++ b/sites/mad03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'ES',

--- a/sites/mad04.jsonnet
+++ b/sites/mad04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'ES',

--- a/sites/mil02.jsonnet
+++ b/sites/mil02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'IT',

--- a/sites/mil03.jsonnet
+++ b/sites/mil03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'IT',

--- a/sites/mil05.jsonnet
+++ b/sites/mil05.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'IT',

--- a/sites/mnl01.jsonnet
+++ b/sites/mnl01.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS9821',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'AS',
     country_code: 'PH',

--- a/sites/nuq07.jsonnet
+++ b/sites/nuq07.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'NA',
     country_code: 'US',

--- a/sites/par02.jsonnet
+++ b/sites/par02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'FR',

--- a/sites/par03.jsonnet
+++ b/sites/par03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'FR',

--- a/sites/par04.jsonnet
+++ b/sites/par04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'FR',

--- a/sites/par05.jsonnet
+++ b/sites/par05.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'FR',

--- a/sites/prg02.jsonnet
+++ b/sites/prg02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3356',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'CZ',

--- a/sites/prg03.jsonnet
+++ b/sites/prg03.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1299',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'CZ',

--- a/sites/prg04.jsonnet
+++ b/sites/prg04.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS3257',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'CZ',

--- a/sites/prg05.jsonnet
+++ b/sites/prg05.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS1273',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'EU',
     country_code: 'CZ',

--- a/sites/syd02.jsonnet
+++ b/sites/syd02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS4826',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'OC',
     country_code: 'AU',

--- a/sites/wlg02.jsonnet
+++ b/sites/wlg02.jsonnet
@@ -18,9 +18,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS38022',
   },
-  switch+: {
-    flow_control: 'no',
-  },
   location+: {
     continent_code: 'OC',
     country_code: 'NZ',


### PR DESCRIPTION
This PR changes the default value for `flow_control` to no and removes the per-site overrides, since in a few days all the M-Lab sites will have flow control disabled anyway.

Also, for the Level3 sites that have been upgraded to 10g recently, `auto_negotiation` should be enabled.

Closes https://github.com/m-lab/siteinfo/issues/96.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/97)
<!-- Reviewable:end -->
