### PR TITLE
Add ipv4_prefix to switches.json

### DIFF
--- a/formats/sites/switches.json.jsonnet
+++ b/formats/sites/switches.json.jsonnet
@@ -9,6 +9,7 @@ local sites = import 'sites.jsonnet';
     switch_model: site.switch.model,
     uplink_port: site.switch.uplink_port,
     uplink_speed: site.transit.uplink,
+    ipv4_prefix: site.network.ipv4.prefix,
   }
   for site in sites
   if site.annotations.type == 'physical'


### PR DESCRIPTION
This PR adds a new `ipv4_prefix` field to `switches.json`. `switches.json` is used by `genconfig.py` (in the https://github.com/m-lab/switch-config repo) to generate the switch configuration. 

Even if `genconfig.py` has started using siteinfo, the ipv4 prefix must  still be specified via a command line flag. 

This change will allow removing that flag from genconfig.py, removing a potential source of human error and also making it possible for that script to generate *all* the switch configurations in a single run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/98)
<!-- Reviewable:end -->
