### PR TITLE
Removes NS record for sns-pb.isc.org.

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -74,7 +74,6 @@ std.lines([
             600       ; Retry
             604800    ; Expire
             300 )     ; Negative caching TTL
-    @       IN      NS      sns-pb.isc.org.
     @       IN      NS      ns-mlab.greenhost.net.
     @       IN      NS      ns.measurementlab.net.
 


### PR DESCRIPTION
The new configuration with ns.measurementlab.net seems to be working just fine, so we can now safely remove the ISC nameserver from the config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/99)
<!-- Reviewable:end -->
