### PR TITLE
Increases the default zone TTL from 5m to 60m.

### DIFF
--- a/formats/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/zones/measurement-lab.org.zone.jsonnet
@@ -66,7 +66,7 @@ std.lines([
     ;
 
     $ORIGIN measurement-lab.org.
-    $TTL    300
+    $TTL    3600
 
     @       IN      SOA     ns.measurementlab.net. support.measurementlab.net. (
             %s        ; Serial


### PR DESCRIPTION
This change is being made after a discussion in the most recent Platform Development meeting concluded that a TTL of 5m may be too small and that 24h may be too large. A 1h TTL was seen to be  middle-of-the-road compromise. Part of the hope of this is to see if this change might budge (lower) some of the persistent OneBox error rates, as some of them may be related to DNS failures that are the result of our current less-than-ideal DNS configuration (1 VM in the US and 1 VM in Western Europe). This may also be alleviated by us moving to Cloud DNS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/107)
<!-- Reviewable:end -->
