### PR TITLE
Fixes a typo in the IPv6 prefix for mad05.

### DIFF
--- a/sites/mad05.jsonnet
+++ b/sites/mad05.jsonnet
@@ -10,7 +10,7 @@ sitesDefault {
       prefix: '93.142.125.192/26',
     },
     ipv6+: {
-      prefix: '2001:5a0:2a00:201::0/64',
+      prefix: '2001:5a0:2a00:201::/64',
     },
   },
   transit+: {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/110)
<!-- Reviewable:end -->
