### PR TITLE
Add server annotation format for uuid-annotator

### DIFF
--- a/formats/sites/annotations.json.jsonnet
+++ b/formats/sites/annotations.json.jsonnet
@@ -1,4 +1,10 @@
 local sites = import 'sites.jsonnet';
+local parseASN(asn) = (
+  if std.length(asn) > 2 then
+    std.parseInt(std.substr(asn, 2, std.length(asn)-2))
+  else
+    0
+);
 [
   {
     local loc = site.location,
@@ -13,7 +19,7 @@ local sites = import 'sites.jsonnet';
       "State": loc.state,
     },
     Network: {
-      local asn = std.parseInt(std.substr(transit.asn, 2, std.length(transit.asn))),
+      local asn = parseASN(transit.asn),
       "ASNumber": asn,
       "ASName": transit.provider,
       "Systems": [

--- a/formats/sites/annotations.json.jsonnet
+++ b/formats/sites/annotations.json.jsonnet
@@ -1,0 +1,29 @@
+local sites = import 'sites.jsonnet';
+[
+  {
+    local loc = site.location,
+    local transit = site.transit,
+    Site: site.name,
+    Geo: {
+      "ContinentCode": loc.continent_code,
+      "CountryCode": loc.country_code,
+      "Latitude": loc.latitude,
+      "Longitude": loc.longitude,
+      "City": loc.city,
+      "State": loc.state,
+    },
+    Network: {
+      local asn = std.parseInt(std.substr(transit.asn, 2, std.length(transit.asn))),
+      "ASNumber": asn,
+      "ASName": transit.provider,
+      "Systems": [
+        {
+          "ASNs": [
+            asn
+          ]
+        }
+      ]
+    }
+  }
+  for site in sites
+]

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -28,6 +28,7 @@ site {
   transit: {
     provider: error 'Must override transit.provider',
     uplink: error 'Must override transit.uplink',
+    asn: error 'Must override transit.uplink',
   },
   switch: {
     auto_negotiation: 'yes',

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -28,7 +28,7 @@ site {
   transit: {
     provider: error 'Must override transit.provider',
     uplink: error 'Must override transit.uplink',
-    asn: error 'Must override transit.uplink',
+    asn: error 'Must override transit.asn',
   },
   switch: {
     auto_negotiation: 'yes',


### PR DESCRIPTION
This change adds a new format to siteinfo that outputs the schema used by the `annotator.ServerAnnotations` type from uuid-annotator. This information would be loaded at start time by the uuid-annotator from the siteinfo API and used to populate the M-Lab Server fields in the uuid archives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/113)
<!-- Reviewable:end -->
