### PR TITLE
Add network information for server annotation

### DIFF
--- a/formats/sites/annotations.json.jsonnet
+++ b/formats/sites/annotations.json.jsonnet
@@ -7,29 +7,40 @@ local parseASN(asn) = (
 );
 [
   {
-    local loc = site.location,
-    local transit = site.transit,
-    Site: site.name,
-    Geo: {
-      "ContinentCode": loc.continent_code,
-      "CountryCode": loc.country_code,
-      "Latitude": loc.latitude,
-      "Longitude": loc.longitude,
-      "City": loc.city,
-      "State": loc.state,
-    },
+    // NOTE: the uuid-annotator uses camel case in exported JSON, so the
+    // following object keys are capitalized accordingly.
+    Name: site.name,
+    // Network allows identifying individual connection CIDR values.
     Network: {
-      local asn = parseASN(transit.asn),
-      "ASNumber": asn,
-      "ASName": transit.provider,
-      "Systems": [
-        {
-          "ASNs": [
-            asn
-          ]
-        }
-      ]
-    }
-  }
+      IPv4: site.network.ipv4.prefix,
+      IPv6: if site.network.ipv6.prefix != null then site.network.ipv6.prefix else "",
+    },
+    Annotation: {
+      local loc = site.location,
+      local transit = site.transit,
+      Site: site.name,
+      // Machine: field will be filled in by the uuid-annotator.
+      Geo: {
+        ContinentCode: loc.continent_code,
+        CountryCode: loc.country_code,
+        Latitude: loc.latitude,
+        Longitude: loc.longitude,
+        City: loc.city,
+        State: loc.state,
+      },
+      Network: {
+        local asn = parseASN(transit.asn),
+        ASNumber: asn,
+        ASName: transit.provider,
+        Systems: [
+          {
+            ASNs: [
+              asn
+            ]
+          }
+        ]
+      }
+    },
+  },
   for site in sites
 ]


### PR DESCRIPTION
This change expands the definition of the annotations format to include the site netblock for use by the uuid-annotator to accept that a given "server" annotation is for an IP address in the site netblock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/117)
<!-- Reviewable:end -->
