### PR TITLE
Allow configuring project on a per-node basis.

### DIFF
--- a/formats/v1/sites/hostnames.json.jsonnet
+++ b/formats/v1/sites/hostnames.json.jsonnet
@@ -8,7 +8,7 @@ local sites = import 'sites.jsonnet';
     ipv6: m.v6.ip,
   }
   for site in sites
-  for mIndex in std.range(1, site.machines.count)
+  for mIndex in std.range(1, std.length(site.machines))
 ] + [
   {
     local e = site.Experiment(mIndex, experiment),
@@ -17,7 +17,7 @@ local sites = import 'sites.jsonnet';
     ipv6: e.v6.ip,
   }
   for site in sites
-  for mIndex in std.range(1, site.machines.count)
+  for mIndex in std.range(1, std.length(site.machines))
   for experiment in experiments
   if (site.annotations.type == 'physical' || experiment.cloud_enabled == true)
 ]

--- a/formats/v1/sites/sites.json.jsonnet
+++ b/formats/v1/sites/sites.json.jsonnet
@@ -18,7 +18,7 @@ local sites = import 'sites.jsonnet';
           for experiment in experiments
         ],
       }
-      for mIndex in std.range(1, site.machines.count)
+      for mIndex in std.range(1, std.length(site.machines))
     ],
   }
   for site in sites

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -24,7 +24,7 @@ local records = std.flattenArrays([
   local d = site.DRAC(mIndex);
   { record: d.Record(), ipv4: d.v4.ip }
   for site in sites
-  for mIndex in std.range(1, site.machines.count)
+  for mIndex in std.range(1, std.length(site.machines))
   if site.annotations.type == 'physical'
 ] + std.flattenArrays([
   // Machines
@@ -35,7 +35,7 @@ local records = std.flattenArrays([
     { record: m.Record('v6'), ipv6: m.v6.ip },
   ]
   for site in sites
-  for mIndex in std.range(1, site.machines.count)
+  for mIndex in std.range(1, std.length(site.machines))
 ]) + std.flattenArrays([
   // Experiments
   local e = site.Experiment(mIndex, experiment);
@@ -51,7 +51,7 @@ local records = std.flattenArrays([
     // do nothing for flat_hostname == false.
   ]
   for site in sites
-  for mIndex in std.range(1, site.machines.count)
+  for mIndex in std.range(1, std.length(site.machines))
   for experiment in experiments
   if (site.annotations.type == 'physical' ||
       experiment.cloud_enabled == true)

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -26,6 +26,7 @@
     local v4net = $.network.ipv4.prefix,
     local v6net = $.network.ipv6.prefix,
     index: m,
+    project: $.machines['mlab' + m].project,
     v4: if v4net != null then {
       ip: (
         if $.annotations.type == 'physical' then (

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -9,9 +9,26 @@ site {
     roundrobin: true,
   },
   machines: {
-    count: 4,
-    disk: 'sda',
-    iface: 'eth0',
+    mlab1: {
+      disk: 'sda',
+      iface: 'eth0',
+      project: 'mlab-oti',
+    },
+    mlab2: {
+      disk: 'sda',
+      iface: 'eth0',
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'sda',
+      iface: 'eth0',
+      project: 'mlab-oti',
+    },
+    mlab4: {
+      disk: 'sda',
+      iface: 'eth0',
+      project: 'mlab-staging',
+    },
   },
   network: {
     ipv4: {

--- a/sites/lga0t.jsonnet
+++ b/sites/lga0t.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      project: 'mlab-sandbox',
+    },
+    mlab2+: {
+      project: 'mlab-sandbox',
+    },
+    mlab2+: {
+      project: 'mlab-sandbox',
+    },
+    mlab2+: {
+      project: 'mlab-sandbox',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '4.14.159.64/26',

--- a/sites/lga1t.jsonnet
+++ b/sites/lga1t.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      project: 'mlab-sandbox',
+    },
+    mlab2+: {
+      project: 'mlab-sandbox',
+    },
+    mlab3+: {
+      project: 'mlab-sandbox',
+    },
+    mlab4+: {
+      project: 'mlab-sandbox',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '4.14.3.0/26',


### PR DESCRIPTION
This PR allows us to configure project on a per node basis. This could be the basis upon which we start to migrate many mlab4 to production. This does not change current v1 output, other than to change the `machines` field of a site and to add a new `project` field to each machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/119)
<!-- Reviewable:end -->
