### PR TITLE
Configures lib/site.jsonnet to output project-subdomain domain names

### DIFF
--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -1,4 +1,17 @@
 {
+  // Returns the appropriate base domain depending on the node project for v2
+  // outputs, else just the standard base domain.
+  BaseDomain(m):: (
+    local domainMap = {
+      'mlab-sandbox': 'mlab-sandbox.measurement-lab.org',
+      'mlab-staging': 'mlab-staging.measurement-lab.org',
+      'mlab-oti': 'mlab-oti.measurement-lab.org',
+    };
+    if std.extVar('version') == 'v2' then
+      '%s' % domainMap[$.machines['mlab' + m].project]
+    else
+      'measurement-lab.org'
+  ),
   // Switch returns a network spec for the site switch.
   Switch():: {
     v4: {
@@ -18,7 +31,7 @@
       ),
     },
     Record():: 'mlab%dd.%s' % [m, $.name],
-    Hostname():: '%s.measurement-lab.org' % self.Record(),
+    Hostname():: '%s.%s' % [self.Record(), $.BaseDomain(m)],
   },
   // Machine returns a network spec for machine index m. The decoration
   // parameter may be used to decorate the machine record and hostname.
@@ -66,7 +79,7 @@
     // decoration if given.
     Record(decoration=''):: 'mlab%d%s.%s' % [m, decoration, $.name],
     // Hostname returns a machine FQDN including the decoration, if given.
-    Hostname(decoration=''):: '%s.measurement-lab.org' % self.Record(decoration),
+    Hostname(decoration=''):: '%s.%s' % [self.Record(decoration), $.BaseDomain(m)],
   },
   // Experiment returns a network spec for the given experiment config on machine
   // index m.
@@ -94,7 +107,7 @@
     // decoration if given.
     Record(decoration=''):: '%s.mlab%d%s.%s' % [expConfig.name, m, decoration, $.name],
     // Hostname returns a machine FQDN including the decoration, if given.
-    Hostname(decoration=''):: '%s.measurement-lab.org' % self.Record(decoration),
+    Hostname(decoration=''):: '%s.%s' % [self.Record(decoration), $.BaseDomain(m)],
   },
 
   // Index4 returns the i-th IPv4 address in the site's ipv4 network.


### PR DESCRIPTION
But only if the version being built is v2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/120)
<!-- Reviewable:end -->
