### PR TITLE
Fixes Cloud DNS nameserver names. They should all start with 'ns-' not 'ns1-'

### DIFF
--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -90,20 +90,20 @@ local primary_headers = |||
     _acme-challenge.www   IN      TXT   zW_JZzJ7gszt1aiONHMlBMag4Zp5dDIiBWjrLHPe2rE
 
     ; Delegate mlab-sandbox subdomain to sandbox Cloud DNS servers.
-    mlab-sandbox     IN     NS      ns1-cloud-c1.googledomains.com.
-                     IN     NS      ns1-cloud-c2.googledomains.com.
-                     IN     NS      ns1-cloud-c3.googledomains.com.
-                     IN     NS      ns1-cloud-c4.googledomains.com.
+    mlab-sandbox     IN     NS      ns-cloud-c1.googledomains.com.
+                     IN     NS      ns-cloud-c2.googledomains.com.
+                     IN     NS      ns-cloud-c3.googledomains.com.
+                     IN     NS      ns-cloud-c4.googledomains.com.
     ; Delegate mlab-staging subdomain to staging Cloud DNS servers.
-    mlab-staging     IN     NS      ns1-cloud-a1.googledomains.com.
-                     IN     NS      ns1-cloud-a2.googledomains.com.
-                     IN     NS      ns1-cloud-a3.googledomains.com.
-                     IN     NS      ns1-cloud-a4.googledomains.com.
+    mlab-staging     IN     NS      ns-cloud-a1.googledomains.com.
+                     IN     NS      ns-cloud-a2.googledomains.com.
+                     IN     NS      ns-cloud-a3.googledomains.com.
+                     IN     NS      ns-cloud-a4.googledomains.com.
     ; Delegate mlab-oti subdomain to staging Cloud DNS servers.
-    mlab-oti         IN     NS      ns1-cloud-d1.googledomains.com.
-                     IN     NS      ns1-cloud-d2.googledomains.com.
-                     IN     NS      ns1-cloud-d3.googledomains.com.
-                     IN     NS      ns1-cloud-d4.googledomains.com.
+    mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
+                     IN     NS      ns-cloud-d2.googledomains.com.
+                     IN     NS      ns-cloud-d3.googledomains.com.
+                     IN     NS      ns-cloud-d4.googledomains.com.
 ||| % if version == "v1" && zone != "clouddns_measurement-lab.org.zone" then soa_ns else '';
 
 local project_headers = |||

--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -15,19 +15,19 @@ std.lines([
     _acme-challenge.www   IN      TXT   zW_JZzJ7gszt1aiONHMlBMag4Zp5dDIiBWjrLHPe2r
 
     ; Delegate mlab-sandbox subdomain to sandbox Cloud DNS servers.
-    mlab-sandbox     IN     NS      ns1-cloud-c1.googledomains.com.
-                     IN     NS      ns1-cloud-c2.googledomains.com.
-                     IN     NS      ns1-cloud-c3.googledomains.com.
-                     IN     NS      ns1-cloud-c4.googledomains.com.
+    mlab-sandbox     IN     NS      ns-cloud-c1.googledomains.com.
+                     IN     NS      ns-cloud-c2.googledomains.com.
+                     IN     NS      ns-cloud-c3.googledomains.com.
+                     IN     NS      ns-cloud-c4.googledomains.com.
     ; Delegate mlab-staging subdomain to staging Cloud DNS servers.
-    mlab-staging     IN     NS      ns1-cloud-a1.googledomains.com.
-                     IN     NS      ns1-cloud-a2.googledomains.com.
-                     IN     NS      ns1-cloud-a3.googledomains.com.
-                     IN     NS      ns1-cloud-a4.googledomains.com.
+    mlab-staging     IN     NS      ns-cloud-a1.googledomains.com.
+                     IN     NS      ns-cloud-a2.googledomains.com.
+                     IN     NS      ns-cloud-a3.googledomains.com.
+                     IN     NS      ns-cloud-a4.googledomains.com.
     ; Delegate mlab-oti subdomain to staging Cloud DNS servers.
-    mlab-oti         IN     NS      ns1-cloud-d1.googledomains.com.
-                     IN     NS      ns1-cloud-d2.googledomains.com.
-                     IN     NS      ns1-cloud-d3.googledomains.com.
-                     IN     NS      ns1-cloud-d4.googledomains.com.
+    mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
+                     IN     NS      ns-cloud-d2.googledomains.com.
+                     IN     NS      ns-cloud-d3.googledomains.com.
+                     IN     NS      ns-cloud-d4.googledomains.com.
   |||,
 ])


### PR DESCRIPTION
Fixes a type I made across all Cloud DNS nameservers. They should all be prefixed with `ns-`, not `ns1-`. Not sure how I got that "1" in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/127)
<!-- Reviewable:end -->
