### PR TITLE
Adds a new --project flag for selecting nodes.

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -480,8 +480,8 @@ def main():
 
     elif options.format == 'prom-targets-sites':
         records = select_prometheus_site_targets(
-            sites, options.select, options.template_target,
-            options.labels, options.physical)
+            sites, options.select, options.template_target, options.labels,
+            options.physical)
         json.dump(records, sys.stdout, indent=4)
     elif options.format == 'hostips':
         # TODO: Added temporarily to work-around-dependency in script-exporter-support.


### PR DESCRIPTION
Passes the value of the `--project` flag to all functions that also want the value of the `--select` flag, where selecting on node project makes sense. These changes should be a no-op for existing users of mlabconfig.py, until those users are upgraded to take advantage of it.

This represents one small change toward moving away from the old "all mlab4s are staging" paradigm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/128)
<!-- Reviewable:end -->
