### PR TITLE
Brings back unit tests to mlabconfig.py, albeit with python 2.7 :/

### DIFF
--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,3 +1,4 @@
 FROM python:2
 
 RUN pip install mock
+

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,0 +1,3 @@
+FROM python:2
+
+RUN pip install mock

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,12 @@ steps:
 # RUN UNIT TESTS
 ############################################################################
 
-- name: python:2
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'python-env', 'Docker.python'
+  ]
+
+- name: python-env
   args: [
     'python', '-m', 'unittest', 'discover', '-s', 'cmd/', '-p', '*_test.py'
   ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '-t', 'python-env', 'Docker.python'
+    'build', '-t', 'python-env', 'Dockerfile.python'
   ]
 
 - name: python-env

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
 # RUN UNIT TESTS
 ############################################################################
 
-- name: python:2-alpine
+- name: python:2
   args: [
     'python', '-m', 'unittest', 'discover', '-s', 'cmd/', '-p', '*_test.py'
   ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,18 @@
+steps:
+
+############################################################################
+# RUN UNIT TESTS
+############################################################################
+
+- name: python:2-alpine
+  args: [
+    'python', '-m', 'unittest', 'discover', '-s', 'cmd/', '-p', '*_test.py'
+  ]
+
 ############################################################################
 # BUILD ARTIFACTS
 ############################################################################
 
-steps:
 # TODO: enable once we can reconstruct .git directory using cbif.
 ## Pull in submodules to run jsonnet unit tests.
 #- name: gcr.io/cloud-builders/git

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '-t', 'python-env', 'Dockerfile.python'
+    'build', '-t', 'python-env', '-f', 'Dockerfile.python', '.'
   ]
 
 - name: python-env

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -1,0 +1,363 @@
+"""Tests for mlabconfig."""
+
+import contextlib
+import logging
+import mlabconfig
+import mock
+import StringIO
+import unittest
+
+
+@contextlib.contextmanager
+def OpenStringIO(sio):
+    """Creates a StringIO object that is context aware.
+
+    OpenStringIO is useful for testing functions that open and write to a file.
+
+    Example:
+        @mock.patch('__builtin__.open')
+        def test_some_function(self, mock_open):
+            output = StringIO()
+            mock_open.return_value = OpenStringIO(output)
+
+            some_function()
+
+            self.assertEqual(output.getvalue(), 'Expected content')
+
+    Args:
+        sio: StringIO.StringIO, the instance returned by 'open'.
+    """
+    try:
+        yield sio
+    finally:
+        # Do not close the StringIO object, so testers can access getvalue().
+        pass
+
+
+class BracketTemplateTest(unittest.TestCase):
+
+    def setUp(self):
+        self.vars = {'var1': 'Spot', 'var2': 'Dog'}
+
+    def test_substitute_when_template_is_correct(self):
+        tmpl = mlabconfig.BracketTemplate('{{var1}} is a {{var2}}')
+
+        actual = tmpl.safe_substitute(self.vars)
+
+        self.assertEqual(actual, 'Spot is a Dog')
+
+    def test_substitute_when_template_is_broken(self):
+        tmpl = mlabconfig.BracketTemplate('var1}} is a {{var2')
+
+        actual = tmpl.safe_substitute(self.vars)
+
+        self.assertEqual(actual, 'var1}} is a {{var2')
+
+    def test_substitute_when_template_is_shell(self):
+        tmpl1 = mlabconfig.BracketTemplate('$var1 == {{var1}}')
+        tmpl2 = mlabconfig.BracketTemplate('${var2} == {{var2}}')
+
+        actual1 = tmpl1.safe_substitute(self.vars)
+        actual2 = tmpl2.safe_substitute(self.vars)
+
+        self.assertEqual(actual1, '$var1 == Spot')
+        self.assertEqual(actual2, '${var2} == Dog')
+
+    def test_substitute_without_value_returns_unchanged_template(self):
+        tmpl = mlabconfig.BracketTemplate('{{evaluated}} {{unevaluated}}')
+
+        actual = tmpl.safe_substitute({'evaluated': 'okay'})
+
+        self.assertEqual(actual, 'okay {{unevaluated}}')
+
+sites = [
+   {
+      "name": "abc01",
+      "annotations": {
+         "type": "physical"
+      },
+      "location": {
+         "city": "Some City",
+         "continent_code": "NA",
+         "country_code": "US",
+         "latitude": 36.850000,
+         "longitude": 74.783000,
+         "metro": "abc",
+         "state": ""
+      },
+      "machines": {
+         "mlab1": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-sandbox"
+         },
+         "mlab2": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-staging"
+         },
+         "mlab3": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-oti"
+         },
+         "mlab4": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-oti"
+         }
+      },
+      "network": {
+         "ipv4": {
+            "dns1": "8.8.8.8",
+            "dns2": "8.8.4.4",
+            "prefix": "192.168.1.0/26",
+         },
+         "ipv6": {
+            "dns1": "2001:4860:4860::8888",
+            "dns2": "2001:4860:4860::8844",
+            "prefix": "2400:1002:4008::/64",
+         }
+      },
+      "nodes": [
+         {
+            "drac": {
+               "hostname": "mlab1d.abc01.measurement-lab.org",
+               "v4": {
+                   "ip": "192.168.1.68"
+               }
+            },
+            "experiments": [
+               {
+                  "cloud_enabled": True,
+                  "flat_hostname": True,
+                  "hostname": "bar.abc.mlab1.abc01.measurement-lab.org",
+                  "index": 2,
+                  "ipv6_enabled": True,
+                  "name": "bar.abc",
+                  "v4": {
+                     "ip": "163.7.129.11"
+                  },
+                  "v6": {
+                     "ip": "2404:138:4009::11"
+                  }
+               },
+            ],
+            "hostname": "mlab1.abc01.measurement-lab.org",
+            "index": 1,
+            "project": "mlab-sandbox",
+            "v4": {
+               "broadcast": "192.168.1.63",
+               "dns1": "8.8.8.8",
+               "dns2": "8.8.4.4",
+               "gateway": "192.168.1.1",
+               "ip": "192.168.1.9",
+               "netmask": "255.255.255.192",
+               "network": "192.168.1.0/26",
+               "subnet": 26
+            },
+            "v6": {
+               "dns1": "2001:4860:4860::8888",
+               "dns2": "2001:4860:4860::8844",
+               "gateway": "2400:1002:4008::1",
+               "ip": "2400:1002:4008::9",
+               "network": "2400:1002:4008::/64",
+               "subnet": 64
+            }
+         },
+      ]
+   },
+]
+
+class MlabconfigTest(unittest.TestCase):
+
+    def setUp(self):
+        self.users = [('User', 'Name', 'username@gmail.com')]
+        self.sites = sites
+        # Turn off logging output during testing (unless CRITICAL).
+        logging.disable(logging.ERROR)
+
+    def assertContainsItems(self, results, expected_items):
+        """Asserts that every element of expected is present in results."""
+        for expected in expected_items:
+            self.assertIn(expected, results)
+
+    def assertDoesNotContainsItems(self, results, unexpected_items):
+        """Asserts that every element of unexpected is NOT in results."""
+        for unexpected in unexpected_items:
+            self.assertNotIn(unexpected, results)
+
+    @mock.patch('__builtin__.open')
+    def test_export_mlab_server_network_config(self, mock_open):
+        stdout = StringIO.StringIO()
+        name_tmpl = '{{hostname}}-foo.ipxe'
+        input_tmpl = StringIO.StringIO('ip={{ipv4_address}} ; echo ${ip} {{extra}}')
+        file_output = StringIO.StringIO()
+        mock_open.return_value = OpenStringIO(file_output)
+
+        mlabconfig.export_mlab_server_network_config(
+            stdout, self.sites, name_tmpl, input_tmpl, 'mlab1.abc01',
+            {'extra': 'value'}, False, 'mlab-sandbox')
+
+        self.assertEqual(
+            file_output.getvalue(), 'ip=192.168.1.9 ; echo ${ip} value')
+
+    def test_select_prometheus_experiment_targets_includes_all_experiments(
+        self):
+        expected_targets = [
+            {
+                'labels': {
+                    'experiment': 'bar.abc',
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'bar.abc.mlab1.abc01.measurement-lab.org:9090'
+                ]
+            },
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_experiment_targets(
+            self.sites, 'mlab-sandbox', None, ['{{hostname}}:9090'], {}, False, False, '',
+            False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(expected_targets, actual_targets)
+
+    def test_select_prometheus_experiment_targets_includes_selected(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org',
+                    'experiment': 'bar.abc'
+                },
+                'targets': [
+                    'bar.abc.mlab1.abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_experiment_targets(
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
+            False, False, '', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(expected_targets, actual_targets)
+
+    def test_select_prometheus_experiment_targets_flattens_names(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org',
+                    'experiment': 'bar.abc'
+                },
+                'targets': [
+                    'bar-abc-mlab1-abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_experiment_targets(
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
+            False, True, '', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(expected_targets, actual_targets)
+
+    def test_select_prometheus_experiment_targets_decorated_names(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org',
+                    'experiment': 'bar.abc'
+                },
+                'targets': [
+                    'bar.abc.mlab1v4.abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_experiment_targets(
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {}, False,
+            False, 'v4', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(expected_targets, actual_targets)
+
+    def test_select_prometheus_node_targets(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'mlab1.abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
+    def test_select_prometheus_node_targets_decorated_names(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'mlab1v6.abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090'], {}, 'v6', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
+    def test_select_prometheus_node_mulitple_targets(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'mlab1.abc01.measurement-lab.org:9090',
+                    'mlab1.abc01.measurement-lab.org:8080'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090', '{{hostname}}:8080'],
+            {}, '', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
+    def test_select_prometheus_site_targets(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'site': 'abc01'
+                },
+                'targets': [
+                    's1.abc01.measurement-lab.org:9116'
+                ]
+            }
+        ]
+
+        actual_targets = mlabconfig.select_prometheus_site_targets(
+            self.sites, None, ['s1.{{sitename}}.measurement-lab.org:9116'], {},
+            False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertItemsEqual(actual_targets, expected_targets)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -301,6 +301,12 @@ class MlabconfigTest(unittest.TestCase):
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)
 
+    def test_select_prometheus_node_targets_excludes_unselected_project(self):
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab-oti", "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
+
+        self.assertEqual(len(actual_targets), 0)
+
     def test_select_prometheus_node_targets_decorated_names(self):
         expected_targets = [
             {

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -17,7 +17,7 @@ def OpenStringIO(sio):
     Example:
         @mock.patch('__builtin__.open')
         def test_some_function(self, mock_open):
-            output = StringIO()
+            output = StringIO.StringIO()
             mock_open.return_value = OpenStringIO(output)
 
             some_function()


### PR DESCRIPTION
This PR cherry-picks (not in the git sense, but in the `cp` sense) the latest version of [mlabconfig.py unit tests from the old operator repository](https://github.com/m-lab/operator/blob/master/plsync/mlabconfig_test.py), and makes any changes necessary to the file for it to work today. I decided to, for now, avoid trying to convert the file to use python3, though this should in theory be pretty easy with `2to3` or similar. I also added one unit test to be sure that selecting on a GCP project that does not exist in the sample sites data yields no Prometheus targets.

For the sake of transparency about what changed (not very much), this is the full diff:

```
--- plsync/mlabconfig_test.py	2019-06-11 14:21:45.512181155 -0500
+++ ../siteinfo/cmd/mlabconfig_test.py	2020-03-12 09:58:33.241472207 -0600
@@ -4,7 +4,6 @@
 import logging
 import mlabconfig
 import mock
-from planetlab import model
 import StringIO
 import unittest
 
@@ -87,11 +86,27 @@
          "state": ""
       },
       "machines": {
-         "count": 4,
-         "disk": "sda",
-         "iface": "eth0"
+         "mlab1": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-sandbox"
+         },
+         "mlab2": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-staging"
+         },
+         "mlab3": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-oti"
+         },
+         "mlab4": {
+           "disk": "sda",
+           "iface": "eth0",
+           "project": "mlab-oti"
+         }
       },
-
       "network": {
          "ipv4": {
             "dns1": "8.8.8.8",
@@ -106,6 +121,12 @@
       },
       "nodes": [
          {
+            "drac": {
+               "hostname": "mlab1d.abc01.measurement-lab.org",
+               "v4": {
+                   "ip": "192.168.1.68"
+               }
+            },
             "experiments": [
                {
                   "cloud_enabled": True,
@@ -124,6 +145,7 @@
             ],
             "hostname": "mlab1.abc01.measurement-lab.org",
             "index": 1,
+            "project": "mlab-sandbox",
             "v4": {
                "broadcast": "192.168.1.63",
                "dns1": "8.8.8.8",
@@ -152,7 +174,6 @@
     def setUp(self):
         self.users = [('User', 'Name', 'username@gmail.com')]
         self.sites = sites
-        self.attrs = [model.Attr('MeasurementLabCentos', disk_max='60000000')]
         # Turn off logging output during testing (unless CRITICAL).
         logging.disable(logging.ERROR)
 
@@ -176,7 +197,7 @@
 
         mlabconfig.export_mlab_server_network_config(
             stdout, self.sites, name_tmpl, input_tmpl, 'mlab1.abc01',
-            {'extra': 'value'}, False)
+            {'extra': 'value'}, False, 'mlab-sandbox')
 
         self.assertEqual(
             file_output.getvalue(), 'ip=192.168.1.9 ; echo ${ip} value')
@@ -196,7 +217,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            self.sites, None, ['{{hostname}}:9090'], {}, False, False, '',
+            self.sites, 'mlab-sandbox', None, ['{{hostname}}:9090'], {}, False, False, '',
             False)
 
         self.assertEqual(len(actual_targets), 1)
@@ -216,7 +237,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            self.sites, "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
             False, False, '', False)
 
         self.assertEqual(len(actual_targets), 1)
@@ -236,7 +257,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            self.sites, "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {},
             False, True, '', False)
 
         self.assertEqual(len(actual_targets), 1)
@@ -256,7 +277,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            self.sites, "bar.abc.mlab1.*", ['{{hostname}}:9090'], {}, False,
+            self.sites, "mlab-sandbox", "bar.abc.mlab1.*", ['{{hostname}}:9090'], {}, False,
             False, 'v4', False)
 
         self.assertEqual(len(actual_targets), 1)
@@ -275,11 +296,17 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_node_targets(
-            self.sites, "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
 
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)
 
+    def test_select_prometheus_node_targets_excludes_unselected_project(self):
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            self.sites, "mlab-oti", "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
+
+        self.assertEqual(len(actual_targets), 0)
+
     def test_select_prometheus_node_targets_decorated_names(self):
         expected_targets = [
             {
@@ -293,7 +320,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_node_targets(
-            self.sites, "mlab1.*", ['{{hostname}}:9090'], {}, 'v6', False)
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090'], {}, 'v6', False)
 
         self.assertEqual(len(actual_targets), 1)
         self.assertItemsEqual(actual_targets, expected_targets)
@@ -312,7 +339,7 @@
         ]
 
         actual_targets = mlabconfig.select_prometheus_node_targets(
-            self.sites, "mlab1.*", ['{{hostname}}:9090', '{{hostname}}:8080'],
+            self.sites, "mlab-sandbox", "mlab1.*", ['{{hostname}}:9090', '{{hostname}}:8080'],
             {}, '', False)
 
         self.assertEqual(len(actual_targets), 1)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/130)
<!-- Reviewable:end -->
