### PR TITLE
Flattens machine names and drac name, too.

### DIFF
--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -1,3 +1,5 @@
+local version = std.extVar('version');
+
 {
   // Returns the appropriate base domain depending on the node project for v2
   // outputs, else just the standard base domain.
@@ -7,7 +9,7 @@
       'mlab-staging': 'mlab-staging.measurement-lab.org',
       'mlab-oti': 'mlab-oti.measurement-lab.org',
     };
-    if std.extVar('version') == 'v2' then
+    if version == 'v2' then
       '%s' % domainMap[$.machines['mlab' + m].project]
     else
       'measurement-lab.org'
@@ -17,7 +19,12 @@
     v4: {
       ip: $.Index4(2),
     },
-    Record():: 's1.%s' % $.name,
+    Record():: (
+      if version == 'v1' then
+        's1.%s' % $.name
+      else
+        's1-%s' % $.name
+    ),
     Hostname():: '%s.measurement-lab.org' % self.Record(),
   },
   // DRAC returns a network spec for the drac attached to machine index m.
@@ -31,7 +38,7 @@
       ),
     },
     Record():: (
-      if std.extVar('version') == 'v1' then
+      if version == 'v1' then
         'mlab%dd.%s' % [m, $.name]
       else
         'mlab%dd-%s' % [m, $.name]
@@ -83,7 +90,7 @@
     // Record returns a machine name suitable for a zone record including the
     // decoration if given.
     Record(decoration=''):: (
-      if std.extVar('version') == 'v1' then
+      if version == 'v1' then
         'mlab%d%s.%s' % [m, decoration, $.name]
       else
         'mlab%d%s-%s' % [m, decoration, $.name]
@@ -118,7 +125,7 @@
     Record(decoration=''):: (
       // For v1 zones we include dotted and dashed/flat hostnames. For anything
       // later than v1 we only include dashed/flat names.
-      if std.extVar('version') == 'v1' then
+      if version == 'v1' then
         '%s.mlab%d%s.%s' % [expConfig.name, m, decoration, $.name]
       else
         '%s-mlab%d%s-%s' % [std.strReplace(expConfig.name, '.', '-'), m, decoration, $.name]

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -30,7 +30,12 @@
           error 'Machine indexes must be within range [1,4]'
       ),
     },
-    Record():: 'mlab%dd.%s' % [m, $.name],
+    Record():: (
+      if std.extVar('version') == 'v1' then
+        'mlab%dd.%s' % [m, $.name]
+      else
+        'mlab%dd-%s' % [m, $.name]
+    ),
     Hostname():: '%s.%s' % [self.Record(), $.BaseDomain(m)],
   },
   // Machine returns a network spec for machine index m. The decoration
@@ -77,7 +82,12 @@
     },
     // Record returns a machine name suitable for a zone record including the
     // decoration if given.
-    Record(decoration=''):: 'mlab%d%s.%s' % [m, decoration, $.name],
+    Record(decoration=''):: (
+      if std.extVar('version') == 'v1' then
+        'mlab%d%s.%s' % [m, decoration, $.name]
+      else
+        'mlab%d%s-%s' % [m, decoration, $.name]
+    ),
     // Hostname returns a machine FQDN including the decoration, if given.
     Hostname(decoration=''):: '%s.%s' % [self.Record(decoration), $.BaseDomain(m)],
   },

--- a/lib/site_test.jsonnet
+++ b/lib/site_test.jsonnet
@@ -114,10 +114,10 @@ test.suite({
       v4v6Site.DRAC(4).Record(),
     ],
     expect: [
-      'mlab1d.mck0t',
-      'mlab2d.mck0t',
-      'mlab3d.mck0t',
-      'mlab4d.mck0t',
+      'mlab1d-mck0t',
+      'mlab2d-mck0t',
+      'mlab3d-mck0t',
+      'mlab4d-mck0t',
     ],
   },
   test_machine_v4: {
@@ -134,8 +134,8 @@ test.suite({
       '255.255.255.192',
       '192.168.1.65',
       '192.168.1.127',
-      'mlab2.mck0t',
-      'mlab2v4.mck0t',
+      'mlab2-mck0t',
+      'mlab2v4-mck0t',
     ],
   },
   test_machine_v6_gateway: {
@@ -164,8 +164,8 @@ test.suite({
       v4v6Site.Machine(2).Record('v6'),
     ],
     expect: [
-      'mlab1v6.mck0t',
-      'mlab2v6.mck0t',
+      'mlab1v6-mck0t',
+      'mlab2v6-mck0t',
     ],
   },
   test_experiment_v4: {

--- a/lib/site_test.jsonnet
+++ b/lib/site_test.jsonnet
@@ -114,10 +114,10 @@ test.suite({
       v4v6Site.DRAC(4).Record(),
     ],
     expect: [
-      'mlab1d-mck0t',
-      'mlab2d-mck0t',
-      'mlab3d-mck0t',
-      'mlab4d-mck0t',
+      if version == 'v1' then 'mlab1d.mck0t' else 'mlab1d-mck0t',
+      if version == 'v1' then 'mlab2d.mck0t' else 'mlab2d-mck0t',
+      if version == 'v1' then 'mlab3d.mck0t' else 'mlab3d-mck0t',
+      if version == 'v1' then 'mlab4d.mck0t' else 'mlab4d-mck0t',
     ],
   },
   test_machine_v4: {
@@ -134,8 +134,8 @@ test.suite({
       '255.255.255.192',
       '192.168.1.65',
       '192.168.1.127',
-      'mlab2-mck0t',
-      'mlab2v4-mck0t',
+      if version == 'v1' then 'mlab2.mck0t' else 'mlab2-mck0t',
+      if version == 'v1' then 'mlab2v4.mck0t' else 'mlab2v4-mck0t',
     ],
   },
   test_machine_v6_gateway: {
@@ -164,8 +164,8 @@ test.suite({
       v4v6Site.Machine(2).Record('v6'),
     ],
     expect: [
-      'mlab1v6-mck0t',
-      'mlab2v6-mck0t',
+      if version == 'v1' then 'mlab1v6.mck0t' else 'mlab1v6-mck0t',
+      if version == 'v1' then 'mlab2v6.mck0t' else 'mlab2v6-mck0t',
     ],
   },
   test_experiment_v4: {

--- a/lib/site_test.jsonnet
+++ b/lib/site_test.jsonnet
@@ -92,6 +92,10 @@ test.suite({
     actual: v4v6Site.Switch().v4.ip,
     expect: '192.168.1.66',
   },
+  test_s1_record: {
+    actual: v4v6Site.Switch().Record(),
+    expect: if version == 'v1' then 's1.mck0t' else 's1-mck0t',
+  },
   test_drac: {
     actual: [
       v4v6Site.DRAC(1).v4.ip,


### PR DESCRIPTION
Previous changes to this repo already created flat experiment names by default for v2 outputs. However, switch names, machine names and drac names were left in dotted format. This PR fixes that so that hopefully **all** names are flat in v2 now. This make the possibility that the wildcard TLS LetsEncrypt certificates we already generate in the cluster could possibly be used for swtiches, DRACs or machines in some way, and if not then at least we are being consistent about flattening all host parts of domain names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/132)
<!-- Reviewable:end -->
