### PR TITLE
Delegates ACME DNS01 challenge records to Cloud DNS

### DIFF
--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -71,6 +71,12 @@ local soa_ns = |||
             300 )     ; Negative caching TTL
     @       IN      NS      ns-mlab.greenhost.net.
     @       IN      NS      ns.measurementlab.net.
+
+    ; Delegate ACME DNS01 challenges for measurement-lab.org to mlab-oti Cloud DNS servers.
+    _acme-challenge  IN     NS      ns-cloud-d1.googledomains.com.
+                     IN     NS      ns-cloud-d2.googledomains.com.
+                     IN     NS      ns-cloud-d3.googledomains.com.
+                     IN     NS      ns-cloud-d4.googledomains.com.
 ||| % serial(std.extVar('serial'), std.extVar('latest'));
 
 local primary_headers = |||
@@ -102,11 +108,6 @@ local primary_headers = |||
                      IN     NS      ns-cloud-a4.googledomains.com.
     ; Delegate mlab-oti subdomain to production Cloud DNS servers.
     mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
-                     IN     NS      ns-cloud-d2.googledomains.com.
-                     IN     NS      ns-cloud-d3.googledomains.com.
-                     IN     NS      ns-cloud-d4.googledomains.com.
-    ; Delegate ACME DNS01 challenges for measurement-lab.org to mlab-oti Cloud DNS servers.
-    _acme-challenge  IN     NS      ns-cloud-d1.googledomains.com.
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.
                      IN     NS      ns-cloud-d4.googledomains.com.

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -89,6 +89,7 @@ local primary_headers = |||
     ; LetsEncrypt ACME DNS challenge record
     _acme-challenge.www   IN      TXT   zW_JZzJ7gszt1aiONHMlBMag4Zp5dDIiBWjrLHPe2rE
 
+
     ; Delegate mlab-sandbox subdomain to sandbox Cloud DNS servers.
     mlab-sandbox     IN     NS      ns-cloud-c1.googledomains.com.
                      IN     NS      ns-cloud-c2.googledomains.com.
@@ -99,8 +100,13 @@ local primary_headers = |||
                      IN     NS      ns-cloud-a2.googledomains.com.
                      IN     NS      ns-cloud-a3.googledomains.com.
                      IN     NS      ns-cloud-a4.googledomains.com.
-    ; Delegate mlab-oti subdomain to staging Cloud DNS servers.
+    ; Delegate mlab-oti subdomain to production Cloud DNS servers.
     mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
+                     IN     NS      ns-cloud-d2.googledomains.com.
+                     IN     NS      ns-cloud-d3.googledomains.com.
+                     IN     NS      ns-cloud-d4.googledomains.com.
+    ; Delegate ACME DNS01 challenges for measurement-lab.org to mlab-oti Cloud DNS servers.
+    _acme-challenge  IN     NS      ns-cloud-d1.googledomains.com.
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.
                      IN     NS      ns-cloud-d4.googledomains.com.


### PR DESCRIPTION
We would like to start using LetsEncrypt wildcard certificates for experiments. Doing this requires DNS01 ACME challenges, which cert-manager handles from the platform clusters. However, the Cloud DNS zone for measurement-lab.org is not yet public. This PR delegates the `_acme-challenge` subdomain to the production Cloud DNS servers, which are the ones that cert-manager can and does update with appropriate challenge TXT records. This PR only applies this delegation to our current v1 zone, not to any Cloud DNS instance. This _should_ start allowing ACME challenges to start working for measurement-lab.org.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/133)
<!-- Reviewable:end -->
