### PR TITLE
Configures CNAME records for ACME challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,13 @@ gcloud dns managed-zones create <name> \
 records for those zones. These nameservers are currently hard coded into the
 Jsonnet zone file(s). If a Cloud DNS zone gets [re]created, then you will need
 to verify the nameservers assigned to the zone and appropriately update the
-Jsonnet zone file(s) with the proper nameservers.
+Jsonnet zone file(s) with the proper nameservers. The nameservers for zones
+can be easily found in the GCP Console or you can find them with gcloud. For
+example:
+```
+gcloud dns record-sets list \
+      --zone "acme-mlab-sandbox-measurement-lab-org" \
+      --name "acme.mlab-sandbox.measurement-lab.org" \
+      --type "NS" \
+      --project mlab-sandbox
+```

--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@ M-Lab Public Site Information Automation
 The latest files can always be found:
 
 * https://siteinfo.mlab-oti.measurementlab.net/v1/index.html
+
+# GCP Cloud DNS zones
+Every GCP project must have these Cloud DNS zones:
+* Name `<project>-measurement-lab-org` for DNS name `<project>.measurement-lab.org`
+* Name `acme-<project>-measurement-lab-org` for DNS name `acme.<project>.measurement-lab.org`
+They can be easily created in the GCP Console or via gcloud like:
+```
+gcloud dns managed-zones create <name> \
+    --description "Appropriate description." \
+    --dns-name "<dns-name>" \
+    --project "${PROJECT}"
+```
+**NOTE**: When a Cloud DNS zone is created Cloud DNS automatically create NS
+records for those zones. These nameservers are currently hard coded into the
+Jsonnet zone file(s). If a Cloud DNS zone gets [re]created, then you will need
+to verify the nameservers assigned to the zone and appropriately update the
+Jsonnet zone file(s) with the proper nameservers.

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -57,7 +57,7 @@ acme_nameservers=$(gcloud dns record-sets list \
     --flatten "rrdatas" \
     --project mlab-sandbox | tail -n +2)
 if [[ -n "${acme_nameservers}" ]]; then
-  echo -e "\n${acme_nameservers}" >> "${SITEINFO_ZONE}"
+  echo -e "\n${acme_nameservers}\n" >> "${SITEINFO_ZONE}"
 else
   echo "No ACME challenge subdomain delegation NS records found in ${PROJECT}.measurement-lab.org zone."
   exit 1

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -55,7 +55,7 @@ acme_nameservers=$(gcloud dns record-sets list \
     --name "acme.${PROJECT}.measurement-lab.org" \
     --type "NS" \
     --format "value(rrdatas.flatten(separator=' '))" \
-    --project mlab-sandbox)
+    --project "${PROJECT}")
 if [[ -n "${acme_nameservers}" ]]; then
   ns_records=$(
     for ns in ${acme_nameservers}; do

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -48,26 +48,6 @@ if [[ "${DOMAIN}" == "measurement-lab.org" ]] && [[ "${PROJECT}" != "mlab-oti" ]
   exit 0
 fi
 
-# ACME subdomain delegation NS records must exist in the Cloud DNS zone. We
-# preserve them here.
-acme_nameservers=$(gcloud dns record-sets list \
-    --zone "acme-${PROJECT}-measurement-lab-org" \
-    --name "acme.${PROJECT}.measurement-lab.org" \
-    --type "NS" \
-    --format "value(rrdatas.flatten(separator=' '))" \
-    --project "${PROJECT}")
-if [[ -n "${acme_nameservers}" ]]; then
-  ns_records=$(
-    for ns in ${acme_nameservers}; do
-      echo "acme IN NS ${ns}"
-    done
-  )
-  echo "${ns_records}" >> "${SITEINFO_ZONE}"
-else
-  echo "ACME challenge subdomain not found."
-  exit 1
-fi
-
 # Deploy the zone to Cloud DNS
 gcloud dns record-sets import "${SITEINFO_ZONE}" \
     --zone-file-format \

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -59,7 +59,7 @@ acme_nameservers=$(gcloud dns record-sets list \
 if [[ -n "${acme_nameservers}" ]]; then
   ns_records=$(
     for ns in ${acme_nameservers}; do
-      echo "acme.${PROJECT}.measurement-lab.org IN NS ${ns}"
+      echo "acme IN NS ${ns}"
     done
   )
   echo "${ns_records}" >> "${SITEINFO_ZONE}"

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -57,7 +57,7 @@ acme_nameservers=$(gcloud dns record-sets list \
     --flatten "rrdatas" \
     --project mlab-sandbox | tail -n +2)
 if [[ -n "${acme_nameservers}" ]]; then
-  echo "${acme_nameservers}" >> "${SITEINFO_ZONE}"
+  echo -e "\n${acme_nameservers}" >> "${SITEINFO_ZONE}"
 else
   echo "No ACME challenge subdomain delegation NS records found in ${PROJECT}.measurement-lab.org zone."
   exit 1

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -57,7 +57,7 @@ acme_nameservers=$(gcloud dns record-sets list \
     --flatten "rrdatas" \
     --project mlab-sandbox | tail -n +2)
 if [[ -n "${acme_nameservers}" ]]; then
-  echo "${acme_nameservers}" >> "${SITEIFO_ZONE}"
+  echo "${acme_nameservers}" >> "${SITEINFO_ZONE}"
 else
   echo "No ACME challenge subdomain delegation NS records found in ${PROJECT}.measurement-lab.org zone."
   exit 1

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -3,7 +3,9 @@ local sites = import 'sites.jsonnet';
 local version = std.extVar('version');
 local zone = std.extVar('zone');
 local project = std.extVar('project');
+
 local flatten(record) = std.strReplace(record, '.', '-');
+
 local serial(current, latest) = (
   if current == '' || latest == '' then
     error 'ERROR: given serial and latest must not be empty!'
@@ -12,6 +14,21 @@ local serial(current, latest) = (
       latest
     else
       std.toString(std.parseInt(current) + 1)
+);
+
+// Cloud DNS nameservers are always of the format:
+//     ns-cloud-[a-z][1-4].googledomains.com
+// This small function returns the appropriate nameserver letter for each
+// project for the ACME subdomain.
+local acme_ns_letter() = (
+  if project == "mlab-sandbox" then
+    "d"
+  else if project == "mlab-staging" then
+    "b"
+  else if project == "mlab-oti" then
+    "a"
+  else
+    error 'Unknown project: %s' % project
 );
 
 local records = std.flattenArrays([
@@ -95,25 +112,36 @@ local primary_headers = |||
     ; LetsEncrypt ACME DNS challenge record
     _acme-challenge.www   IN      TXT   zW_JZzJ7gszt1aiONHMlBMag4Zp5dDIiBWjrLHPe2rE
 
-
-    ; Delegate mlab-sandbox subdomain to sandbox Cloud DNS servers.
+    ;
+    ; GCP project subdomain delegations to Cloud DNS
+    ;
     mlab-sandbox     IN     NS      ns-cloud-c1.googledomains.com.
                      IN     NS      ns-cloud-c2.googledomains.com.
                      IN     NS      ns-cloud-c3.googledomains.com.
                      IN     NS      ns-cloud-c4.googledomains.com.
-    ; Delegate mlab-staging subdomain to staging Cloud DNS servers.
     mlab-staging     IN     NS      ns-cloud-a1.googledomains.com.
                      IN     NS      ns-cloud-a2.googledomains.com.
                      IN     NS      ns-cloud-a3.googledomains.com.
                      IN     NS      ns-cloud-a4.googledomains.com.
-    ; Delegate mlab-oti subdomain to production Cloud DNS servers.
     mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.
                      IN     NS      ns-cloud-d4.googledomains.com.
+
+    ;
+    ; Delegate acme subdomains to Cloud DNS servers.
+    acme             IN     NS      ns-cloud-%s1.googledomains.com.
+                     IN     NS      ns-cloud-%s2.googledomains.com.
+                     IN     NS      ns-cloud-%s3.googledomains.com.
+                     IN     NS      ns-cloud-%s4.googledomains.com.
+
 ||| % [
   if version == "v1" && zone != "clouddns_measurement-lab.org.zone" then soa_ns else '',
   project,
+  acme_ns_letter(),
+  acme_ns_letter(),
+  acme_ns_letter(),
+  acme_ns_letter(),
 ];
 
 local project_headers = |||

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -84,7 +84,9 @@ local primary_headers = |||
     www     IN      A       151.101.1.195
     www     IN      A       151.101.65.195
 
-    ; ACME challenge CNAME redirect for cert-manager/LetsEncrypt
+    ; ACME challenge CNAME redirect for cert-manager/LetsEncrypt. In this
+    ; configuration cert-manager will automatically create the record that the
+    ; CNAME points to instead of the usual _acme-challge.* record.
     _acme-challenge       IN      CNAME mlab.acme.%s.measurement-lab.org.
 
     ; Google site verification to use this domain in Firebase


### PR DESCRIPTION
This PR configures the appropriate CNAME records in each zone to be able to support having cert-manager use a dedicated  zone for ACME challenges so that it doesn't have full write permissions to our primary zones files.

Since our zones get overwritten every deployment, this PR also includes changes to `deploy_dns.sh` to preserve the `acme` subdomain delegation to the new dedicate zones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/135)
<!-- Reviewable:end -->
