### PR TITLE
Add short names for ndt and neubot

### DIFF
--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -23,8 +23,9 @@ apt update
 apt install -y jq
 
 # Make sure that every experiment has the same number of RRs.
+# NOTE: this matches v1 and v2 hostname. It does not match machine names.
 UNIQ_EXP_RR_COUNTS=$(
-  grep -oP '^([a-z-]+?)(?=[.-]mlab[1-4])' "${SITEINFO_ZONE}" \
+  grep -oP '^([a-z.-]+)[.-]mlab(?=[1-4])' "${SITEINFO_ZONE}" \
     | sort | uniq -c | awk '{print $1}' | uniq
 )
 UNIQ_EXP_RR_COUNT=$(echo "${UNIQ_EXP_RR_COUNTS}" | wc -w)

--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -15,6 +15,10 @@ local default = {
     rsync_modules: ['ndt'],
   },
   default {
+    index: 2,
+    name: 'ndt',
+  },
+  default {
     index: 3,
     name: 'revtr',
   },
@@ -27,5 +31,9 @@ local default = {
     flat_hostname: true,
     name: 'neubot.mlab',
     rsync_modules: ['neubot'],
+  },
+  default {
+    index: 10,
+    name: 'neubot',
   },
 ]

--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -16,6 +16,8 @@ local default = {
   },
   default {
     index: 2,
+    flat_hostname: true,
+    cloud_enabled: true,
     name: 'ndt',
   },
   default {
@@ -34,6 +36,7 @@ local default = {
   },
   default {
     index: 10,
+    flat_hostname: true,
     name: 'neubot',
   },
 ]


### PR DESCRIPTION
This change adds a short name for "ndt" and "neubot" and provides a migration path for mlab-ns and other legacy users of the "iupui" or "mlab" parts of ndt and neubot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/137)
<!-- Reviewable:end -->
