### PR TITLE
Adds .decode('utf-8') when reading json-decoding the data returned by urllib

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -457,7 +457,8 @@ def select_prometheus_site_targets(sites, select_regex, target_templates,
 def main():
     (options, _) = parse_flags()
 
-    sites = json.loads(urllib.request.urlopen(options.sites).read())
+    sites = json.loads(
+        urllib.request.urlopen(options.sites).read().decode('utf-8'))
 
     if options.format == 'server-network-config':
         with open(options.template_input) as template:


### PR DESCRIPTION
prometheus-support builds are failing with:

```
+python3 ./[secure]config.py --format=prom-targets --sites https://siteinfo.[secure]-sandbox.measurementlab.net/v2/sites/sites.json '--template_target={{hostname}}:443' --label service=ndt7 --label module=tcp_v4_online --project [secure]-sandbox --select ndt.iupui
Traceback (most recent call last):
  File "./[secure]config.py", line 501, in <module>
    main()
  File "./[secure]config.py", line 460, in main
    sites = json.loads(urllib.request.urlopen(options.sites).read())
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```
This PR passes the data returned by urllib through `.decode('utf-8')`. I do not get this error on my local machine, even without `.decode('utf-8')`. Something apparently changed in python 3.6 making this decode step unnecessary, but adding it does not break thing in >3.6 (I have 3.7), and should make things work in older versions of python3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/140)
<!-- Reviewable:end -->
