### PR TITLE
Fixes issue #134 + adds v2 switch names to v1 zones

### DIFF
--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -38,6 +38,11 @@ fi
 # generated zone file.
 SITE_COUNT=$(jq '. | length' /workspace/output/v1/sites/switches.json)
 SW_RR_COUNT=$(grep '^s1' "${SITEINFO_ZONE}" | wc -l)
+# v1 zones contain both v1 and v2 switch names, so will have exactly double the
+# count of switch records.
+if [[ $VERSION == "v1" ]]; then
+  SW_RR_COUNT=$(($SW_RR_COUNT / 2))
+fi
 if [[ "${SITE_COUNT}" -ne "${SW_RR_COUNT}" ]]; then
   echo "Not every site has a corresponding switch RR in the zone."
   exit 1

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -33,9 +33,11 @@ local acme_ns_letter() = (
 
 local records = std.flattenArrays([
   // Routers & switches
+  local s1 = site.Switch();
   [
-    local s1 = site.Switch();
+    // Add both v1 and v2 switch names for all versions.
     { record: s1.Record(), ipv4: s1.v4.ip },
+    { record: s1.Record('v2'), ipv4: s1.v4.ip },
   ]
   for site in sites
   if site.annotations.type == 'physical'

--- a/formats/v1/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v1/zones/measurement-lab.org.zone.jsonnet
@@ -37,7 +37,8 @@ local records = std.flattenArrays([
   [
     // Add both v1 and v2 switch names for all versions.
     { record: s1.Record(), ipv4: s1.v4.ip },
-    { record: s1.Record('v2'), ipv4: s1.v4.ip },
+    if version == 'v1' then
+      { record: s1.Record('v2'), ipv4: s1.v4.ip },
   ]
   for site in sites
   if site.annotations.type == 'physical'

--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -1,3 +1,16 @@
+local sites = import 'sites.jsonnet';
+local version = std.extVar('version');
+
+local records = std.flattenArrays([
+  // Routers & switches
+  local s1 = site.Switch();
+  [
+    { record: s1.Record(), ipv4: s1.v4.ip },
+  ]
+  for site in sites
+  if site.annotations.type == 'physical'
+]);
+
 std.lines([
   |||
     $ORIGIN measurement-lab.org.
@@ -29,5 +42,10 @@ std.lines([
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.
                      IN     NS      ns-cloud-d4.googledomains.com.
-  |||,
+
+  |||
+] + [
+  '%-32s  IN  A   \t%s' % [row.record, row.ipv4]
+  for row in records
+  if row != null && std.objectHas(row, 'ipv4') && row.ipv4 != ''
 ])

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -19,8 +19,10 @@ local version = std.extVar('version');
     v4: {
       ip: $.Index4(2),
     },
-    Record():: (
-      if version == 'v1' then
+    // otherVersion allow the caller to override the global version.
+    Record(otherVersion=''):: (
+      local v = if otherVersion != '' then otherVersion else version;
+      if v == 'v1' then
         's1.%s' % $.name
       else
         's1-%s' % $.name


### PR DESCRIPTION
This PR fixes issue #134 in which switch records were not included in the base v2 measurement-lab.org domain.

Additionally, since switches are sort of a special case, not (currently) belonging to any particular project, this PR adds v2 switch names (e.g., s1-den04) to the v1 zones to ease the transition from v1 to v2 naming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/141)
<!-- Reviewable:end -->
