### PR TITLE
Adds machine model to default site template, and to any site files needing it.

### DIFF
--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -12,21 +12,25 @@ site {
     mlab1: {
       disk: 'sda',
       iface: 'eth0',
+      model: 'r630',
       project: 'mlab-oti',
     },
     mlab2: {
       disk: 'sda',
       iface: 'eth0',
+      model: 'r630',
       project: 'mlab-oti',
     },
     mlab3: {
       disk: 'sda',
       iface: 'eth0',
+      model: 'r630',
       project: 'mlab-oti',
     },
     mlab4: {
       disk: 'sda',
       iface: 'eth0',
+      model: 'r630',
       project: 'mlab-staging',
     },
   },

--- a/sites/hkg01.jsonnet
+++ b/sites/hkg01.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      model: 'r640',
+    },
+    mlab2+: {
+      model: 'r640',
+    },
+    mlab3+: {
+      model: 'r640',
+    },
+    mlab4+: {
+      model: 'r640',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '183.178.65.0/26',

--- a/sites/hkg02.jsonnet
+++ b/sites/hkg02.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      model: 'r640',
+    },
+    mlab2+: {
+      model: 'r640',
+    },
+    mlab3+: {
+      model: 'r640',
+    },
+    mlab4+: {
+      model: 'r640',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '64.235.254.0/26',

--- a/sites/hnd01.jsonnet
+++ b/sites/hnd01.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      model: 'r620',
+    },
+    mlab2+: {
+      model: 'r620',
+    },
+    mlab3+: {
+      model: 'r620',
+    },
+    mlab4+: {
+      model: 'r620',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '203.178.130.192/26',


### PR DESCRIPTION
We keep track of switch models in siteinfo, and should also keep track of machine model. This will become increasingly important as we get more sites running R640s and the machine models on the platform become not alike.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/143)
<!-- Reviewable:end -->
