### PR TITLE
Deployes the v2 measurement-lab.org zone to Cloud DNS instead of the v1 zone.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -103,8 +103,8 @@ steps:
   env:
   - 'PROJECT=${PROJECT_ID}'
   - 'DOMAIN=measurement-lab.org'
-  - 'ZONEFILE=clouddns_measurement-lab.org.zone'
-  - 'VERSION=v1'
+  - 'ZONEFILE=measurement-lab.org.zone'
+  - 'VERSION=v2'
 
 # Deploy the v2 measurement-lab.org project subdomain zone to Cloud DNS
 - name: gcr.io/cloud-builders/gcloud

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -22,16 +22,20 @@ CLOUDDNS_NORMALIZED="/workspace/clouddns.normalized"
 apt update
 apt install -y jq
 
-# Make sure that every experiment has the same number of RRs.
-# NOTE: this matches v1 and v2 hostname. It does not match machine names.
-UNIQ_EXP_RR_COUNTS=$(
-  grep -oP '^([a-z.-]+)[.-]mlab(?=[1-4])' "${SITEINFO_ZONE}" \
-    | sort | uniq -c | awk '{print $1}' | uniq
-)
-UNIQ_EXP_RR_COUNT=$(echo "${UNIQ_EXP_RR_COUNTS}" | wc -w)
-if [[ "${UNIQ_EXP_RR_COUNT}" -ne "1" ]]; then
-  echo "Not all experiments have the same number of RRs."
-  exit 1
+# The v2 zone for measurement-lab.org does not contain experiment records. All
+# experiment records are in the project subdomain zones, so do not run this
+# test unless this is a project subdomain.
+if [[ "${DOMAIN}" != "measurement-lab.org" ]]; then
+  # Make sure that every experiment has the same number of RRs.
+  UNIQ_EXP_RR_COUNTS=$(
+    grep -oP '^([a-z.-]+)[.-]mlab(?=[1-4])' "${SITEINFO_ZONE}" \
+      | sort | uniq -c | awk '{print $1}' | uniq
+  )
+  UNIQ_EXP_RR_COUNT=$(echo "${UNIQ_EXP_RR_COUNTS}" | wc -w)
+  if [[ "${UNIQ_EXP_RR_COUNT}" -ne "1" ]]; then
+    echo "Not all experiments have the same number of RRs."
+    exit 1
+  fi
 fi
 
 # Make sure that every switch in switches.json has a corresponding s1.* RR in the


### PR DESCRIPTION
We never did use the v1 measurement-lab.org zone in Cloud DNS. This PR deploys the v2 zone to the production instance in Cloud DNS. Once this is done, the next step will be to change the glue records for the domain with the registrar to complete the migration to Cloud DNS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/147)
<!-- Reviewable:end -->
