### PR TITLE
Adds missing _acme-challenge CNAME for DNS01 validation

### DIFF
--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -24,8 +24,13 @@ std.lines([
     ; Google site verification to use this domain in Firebase
     @                     IN      TXT   google-site-verification=YJspItE9L3D8mw76XKHxEGb7x9usph7x_CsqFQbUK28
 
-    ; LetsEncrypt ACME DNS challenge record
+    ; LetsEncrypt ACME DNS01 challenge record for HTTPS redirects of
+    ; www.measurement-lab.org to www.measurementlab.net by Firebase
     _acme-challenge.www   IN      TXT   zW_JZzJ7gszt1aiONHMlBMag4Zp5dDIiBWjrLHPe2r
+
+    ; LetsEncrypt ACME DNS01 challenge. cert-manager autocreates this target
+    ; when needed for validation.
+    _acme-challenge       IN      CNAME mlab.acme.mlab-oti.measurement-lab.org.
 
     ; Delegate mlab-sandbox subdomain to sandbox Cloud DNS servers.
     mlab-sandbox     IN     NS      ns-cloud-c1.googledomains.com.


### PR DESCRIPTION
This record is in the old zone, and I had failed to add it to the v2 zone for measurement-lab.org. We probably don't even need the `.*.measurement-lab.org` domain in the certificate any longer, but  to be safe there is no harm in including for the foreseeable future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/149)
<!-- Reviewable:end -->
