### PR TITLE
Temporarily removes BOG05, which was mistakenly assigned same IPv4 prefix as LHR07

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -22,6 +22,9 @@ local sites = {
   bog02: import 'sites/bog02.jsonnet',
   bog03: import 'sites/bog03.jsonnet',
   bog04: import 'sites/bog04.jsonnet',
+  // bog05.jsonnet current contains a bad IPv4 prefix. The prefix is already
+  // used by LHR07. Waiting for Telecom Italia to clarify/correct. For now,
+  // comment out BOG05.
   //bog05: import 'sites/bog05.jsonnet',
   bom01: import 'sites/bom01.jsonnet',
   bom02: import 'sites/bom02.jsonnet',


### PR DESCRIPTION
In staging, we got a `MachineRunningWithoutK8sNode` alert for mlab4-bog05, which is a new Telecom Italia that will be deployed. However, the site doesn't exist yet. Yet somehow mlab[1-4]-bog05 were pingable. I looked to see if this was a case of an IPv4 prefix already being used by some existing site, and sure enough it is the same as the already deployed Telecom Italia site LOS07. This PR temporarily removes BOG05 until we can figure out what the right IPv4 prefix is for BOG05.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/154)
<!-- Reviewable:end -->
