### PR TITLE
Fixes IPv4 prefixes for GIG02 and BOG05

### DIFF
--- a/sites/bog05.jsonnet
+++ b/sites/bog05.jsonnet
@@ -7,7 +7,7 @@ sitesDefault {
   },
   network+: {
     ipv4+: {
-      prefix: '162.213.96.0/26',
+      prefix: '162.213.97.64/26',
     },
     ipv6+: {
       prefix: null

--- a/sites/gig02.jsonnet
+++ b/sites/gig02.jsonnet
@@ -7,7 +7,7 @@ sitesDefault {
   },
   network+: {
     ipv4+: {
-      prefix: '162.213.96.64/26',
+      prefix: '162.213.97.128/26',
     },
     ipv6+: {
       prefix: null,


### PR DESCRIPTION
The same IPv4 prefixes were specified for multiple sites. BOG05 was given the same prefix as for LHR07, and GIG02 was given the same prefix as for MIL06. ThIs PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/155)
<!-- Reviewable:end -->
