### PR TITLE
Add machines override for mnl02

### DIFF
--- a/sites/mnl02.jsonnet
+++ b/sites/mnl02.jsonnet
@@ -5,6 +5,20 @@ sitesDefault {
   annotations+: {
     type: 'physical',
   },
+  machines+: {
+    mlab1+: {
+      model: 'r640',
+    },
+    mlab2+: {
+      model: 'r640',
+    },
+    mlab3+: {
+      model: 'r640',
+    },
+    mlab4+: {
+      model: 'r640',
+    },
+  },
   network+: {
     ipv4+: {
       prefix: '103.43.213.128/26',


### PR DESCRIPTION
The default value is R630, so unless we override the field it'll be wrong for most new sites.
I think there are other recent sites where didn't set this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/159)
<!-- Reviewable:end -->
