### PR TITLE
Fixes a few malformed/malspecified jsonnet site files

### DIFF
--- a/sites/lba01.jsonnet
+++ b/sites/lba01.jsonnet
@@ -42,20 +42,6 @@ sitesDefault {
   },
   transit+: {
     asn: 'AS33920',
-  machines+: {
-    mlab1+: {
-      model: 'r630',
-    },
-    mlab2+: {
-      model: 'r630',
-    },
-    mlab3+: {
-      model: 'r630',
-    },
-    mlab4+: {
-      model: 'r630',
-    },
-  },
     provider: '(aq) network+s limited',
     uplink: '1g',
   },

--- a/sites/lga0t.jsonnet
+++ b/sites/lga0t.jsonnet
@@ -7,30 +7,20 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab2+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab3+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab4+: {
+      model: 'r630',
       project: 'mlab-sandbox',
-    },
-  },
-  machines+: {
-    mlab1+: {
-      model: 'r630',
-    },
-    mlab2+: {
-      model: 'r630',
-    },
-    mlab3+: {
-      model: 'r630',
-    },
-    mlab4+: {
-      model: 'r630',
     },
   },
   network+: {

--- a/sites/lga1t.jsonnet
+++ b/sites/lga1t.jsonnet
@@ -7,19 +7,19 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
-      model: 'r630',
+      model: 'r620',
       project: 'mlab-sandbox',
     },
     mlab2+: {
-      model: 'r630',
+      model: 'r620',
       project: 'mlab-sandbox',
     },
     mlab3+: {
-      model: 'r630',
+      model: 'r640',
       project: 'mlab-sandbox',
     },
     mlab4+: {
-      model: 'r630',
+      model: 'r640',
       project: 'mlab-sandbox',
     },
   },

--- a/sites/lga1t.jsonnet
+++ b/sites/lga1t.jsonnet
@@ -7,30 +7,20 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab2+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab3+: {
+      model: 'r630',
       project: 'mlab-sandbox',
     },
     mlab4+: {
+      model: 'r630',
       project: 'mlab-sandbox',
-    },
-  },
-  machines+: {
-    mlab1+: {
-      model: 'r630',
-    },
-    mlab2+: {
-      model: 'r630',
-    },
-    mlab3+: {
-      model: 'r630',
-    },
-    mlab4+: {
-      model: 'r630',
     },
   },
   network+: {


### PR DESCRIPTION
PR #181 broke or mis-specified a few site jsonnet files. For example, `machines+` was defined twice for the lga0t and lga1t sites, causing them to look like production sites (e.g., mlab1-lga0t.mlab-oti.measurement-lab.org).  The changes in PR #181 were largely generated by a shell script. I'm not sure what went wrong, but this should resolve the few files that got broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/182)
<!-- Reviewable:end -->
