### PR TITLE
Enables auto-negotiation on uplink port for TNR01

### DIFF
--- a/sites/tnr01.jsonnet
+++ b/sites/tnr01.jsonnet
@@ -32,9 +32,6 @@ sitesDefault {
     uplink: '10g',
     asn: 'AS37054',
   },
-  switch+: {
-    auto_negotiation: 'no',
-  },
   location+: {
     continent_code: 'AF',
     country_code: 'MG',


### PR DESCRIPTION
In PR #183 I forgot/failed to remove the config for the old 1g uplink that set auto-negotiation of the link to false. This PR resolves that small issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/184)
<!-- Reviewable:end -->
