### PR TITLE
Sets a global PROJECT_ID var for cbif

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,7 @@ options:
   # Provide information for cbif to reconstruct .git config.
   - COMMIT_SHA=$COMMIT_SHA
   - GIT_ORIGIN_URL=https://github.com/m-lab/siteinfo.git
+  - PROJECT_ID=$PROJECT_ID
 
 steps:
 


### PR DESCRIPTION
This was an oversight from PR #185. I didn't previously realize that `cbif` required this env variable, but it makes sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/186)
<!-- Reviewable:end -->
