### PR TITLE
Sets SINGLE_COMMAND=true for all siteinfo-cbif steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -92,6 +92,7 @@ steps:
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
   env:
   - PROJECT_IN=mlab-staging,mlab-oti
+  - SINGLE_COMMAND=true
   args: [
     '/go/bin/cbctl', '-project=$PROJECT_ID',
                      '-repo=epoxy-images',
@@ -104,6 +105,7 @@ steps:
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
   env:
   - PROJECT_IN=mlab-staging,mlab-oti
+  - SINGLE_COMMAND=true
   args: [
     '/go/bin/cbctl', '-project=$PROJECT_ID',
                      '-repo=epoxy-images',
@@ -116,6 +118,7 @@ steps:
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
   env:
   - PROJECT_IN=mlab-staging,mlab-oti
+  - SINGLE_COMMAND=true
   args: [
     '/go/bin/cbctl', '-project=$PROJECT_ID',
                      '-repo=switch-config',


### PR DESCRIPTION
This PR sets the env variable SINGLE_COMMAND=true for all remote build trigger steps. If this isn't set, `cbif` will apparently attempt to run each arg as a separate command. The [documentation for the flag](https://github.com/m-lab/gcp-config/blob/master/cmd/cbif/main.go#L51) seems misleading to me, but I may be reading it wrong:

> Run each argument as an individual command.

I read that to mean that to mean the opposite of what the flag apparently does??

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/187)
<!-- Reviewable:end -->
