### PR TITLE
Uses Github token from Secret Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ The latest files can always be found:
 
 * https://siteinfo.mlab-oti.measurementlab.net/v1/index.html
 
-# GCP Cloud DNS zones
+## GCP Cloud DNS zones
+
 Every GCP project must have these Cloud DNS zones:
+
 * Name `<project>-measurement-lab-org` for DNS name `<project>.measurement-lab.org`
-* Name `acme-<project>-measurement-lab-org` for DNS name `acme.<project>.measurement-lab.org`
+* Name `acme-<project>-measurement-lab-org` for DNS name
+  `acme.<project>.measurement-lab.org`
+
 They can be easily created in the GCP Console or via gcloud like:
-```
+
+```lang-sh
 gcloud dns managed-zones create <name> \
     --description "Appropriate description." \
     --dns-name "<dns-name>" \
     --project "${PROJECT}"
 ```
+
 **NOTE**: When a Cloud DNS zone is created Cloud DNS automatically create NS
 records for those zones. These nameservers are currently hard coded into the
 Jsonnet zone file(s). If a Cloud DNS zone gets [re]created, then you will need
@@ -24,10 +30,49 @@ to verify the nameservers assigned to the zone and appropriately update the
 Jsonnet zone file(s) with the proper nameservers. The nameservers for zones
 can be easily found in the GCP Console or you can find them with gcloud. For
 example:
-```
+
+```lang-sh
 gcloud dns record-sets list \
       --zone "acme-mlab-sandbox-measurement-lab-org" \
       --name "acme.mlab-sandbox.measurement-lab.org" \
       --type "NS" \
       --project mlab-sandbox
 ```
+
+## Triggering builds in other repositories
+
+The Cloud Build configuration for this repository has several steps which
+trigger builds in other repositories (e.g, epoxy-images, switch-config). It does
+this by leveraging the `cbctl` command from the gcp-config repository. For the
+mlab-staging and mlab-oti projects, this involves querying the Github API to find
+the appropriate build reference (i.e., release tag name or branch). For private
+repositories (like switch-config), this requires the Github client to
+authenticate to the Github API. This is done by leveraging a [Github personal
+access
+tokens](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+A personal access token was created under the "M-Lab Machine User" Github
+account for this purpose. In order for builds in this repository to access the
+token, the token is [stored as a secret in the GCP Secret
+Manager](https://cloud.google.com/build/docs/securing-builds/use-secrets). The
+secret can be created with this command:
+
+```lang-sh
+echo <token> | gcloud secrets create siteinfo-builds-github-token --data-file=- --project <project>
+```
+
+You will then need to make sure that the Cloud Build service account for the
+project has access to the secret. To do this you need to know the email of the
+default Cloud Build service account for the project. You can find this in the
+GCP Web Console by going to TOOLS -> Cloud Build -> Settings. Once you have this
+you can run:
+
+```lang-sh
+gcloud secrets add-iam-policy-binding siteinfo-builds-github-token \
+      --member 'serviceAccount:<service-account>'
+      --role 'roles/secretmanager.secretAccessor'
+      --project <project>
+```
+
+You can refer to the cloudbuild.yaml file in this repository to see how this
+secret is used in a build, or you can read [the documentation on using secrets
+from the Secret Manager in builds](https://cloud.google.com/build/docs/securing-builds/use-secrets).

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -126,7 +126,7 @@ steps:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   - SINGLE_COMMAND=true
   args:
-  - '-c',
+  - '-c'
   - |
     /go/bin/cbif
     /go/bin/cbctl -project=$PROJECT_ID

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -123,7 +123,7 @@ steps:
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
   entrypoint: /bin/bash
   env:
-  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  - PROJECT_IN=mlab-staging,mlab-oti
   - SINGLE_COMMAND=true
   args:
   - '-c'
@@ -133,7 +133,6 @@ steps:
     -project=$PROJECT_ID
     -repo=switch-config
     -trigger_name=switch-config
-    -branch=master
     trigger
   secretEnv:
   - GITHUB_TOKEN

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,12 +7,8 @@ options:
 
 availableSecrets:
   secretManager:
-  - versionName: projects/581276032543/secrets/siteinfo-builds-github-token/versions/latest
-    env: GITHUB_TOKEN_mlab-sandbox
-  - versionName: projects/240028626237/secrets/siteinfo-builds-github-token/versions/latest
-    env: GITHUB_TOKEN_mlab-staging
-  - versionName: projects/515150309683/secrets/siteinfo-builds-github-token/versions/latest
-    env: GITHUB_TOKEN_mlab-oti
+  - versionName: projects/${PROJECT_NUMBER}/secrets/siteinfo-builds-github-token/versions/latest
+    env: GITHUB_TOKEN
 
 steps:
 
@@ -132,12 +128,12 @@ steps:
     '/go/bin/cbctl', '-project=$PROJECT_ID',
                      '-repo=switch-config',
                      '-trigger_name=switch-config',
-                     '-github_token=$$GITHUB_TOKEN_${PROJECT_ID}',
+                     '-github_token=$$GITHUB_TOKEN',
                      '-branch=master',
                      'trigger'
   ]
   secretEnv:
-  - GITHUB_TOKEN_${PROJECT_ID}
+  - GITHUB_TOKEN
 
 # Deploy the primary measurement-lab.org zone to Cloud DNS.
 - name: gcr.io/cloud-builders/gcloud

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -133,7 +133,6 @@ steps:
     -project=$PROJECT_ID
     -repo=switch-config
     -trigger_name=switch-config
-    -github_token=$$GITHUB_TOKEN
     -branch=master
     trigger
   secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -129,12 +129,13 @@ steps:
   - '-c'
   - >
     /go/bin/cbif
-    /go/bin/cbctl -project=$PROJECT_ID
-                  -repo=switch-config
-                  -trigger_name=switch-config
-                  -github_token=$$GITHUB_TOKEN
-                  -branch=master
-                  trigger
+    /go/bin/cbctl
+    -project=$PROJECT_ID
+    -repo=switch-config
+    -trigger_name=switch-config
+    -github_token=$$GITHUB_TOKEN
+    -branch=master
+    trigger
   secretEnv:
   - GITHUB_TOKEN
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,15 @@ options:
   - GIT_ORIGIN_URL=https://github.com/m-lab/siteinfo.git
   - PROJECT_ID=$PROJECT_ID
 
+availableSecrets:
+  secretManager:
+  - versionName: projects/581276032543/secrets/siteinfo-builds-github-token/versions/latest
+    env: GITHUB_TOKEN_mlab-sandbox
+  - versionName: projects/240028626237/secrets/siteinfo-builds-github-token/versions/latest
+    env: GITHUB_TOKEN_mlab-staging
+  - versionName: projects/515150309683/secrets/siteinfo-builds-github-token/versions/latest
+    env: GITHUB_TOKEN_mlab-oti
+
 steps:
 
 ############################################################################
@@ -117,12 +126,14 @@ steps:
 # new sites, and deploy them to GCS.
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
   env:
-  - PROJECT_IN=mlab-staging,mlab-oti
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   - SINGLE_COMMAND=true
   args: [
     '/go/bin/cbctl', '-project=$PROJECT_ID',
                      '-repo=switch-config',
                      '-trigger_name=switch-config',
+                     '-github_token=$$GITHUB_TOKEN_${PROJECT_ID}',
+                     '-branch=master',
                      'trigger'
   ]
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -127,7 +127,7 @@ steps:
   - SINGLE_COMMAND=true
   args:
   - '-c'
-  - |
+  - >
     /go/bin/cbif
     /go/bin/cbctl -project=$PROJECT_ID
                   -repo=switch-config

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -121,17 +121,20 @@ steps:
 # Trigger a switch-config build, which will build switch configurations for any
 # new sites, and deploy them to GCS.
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif
+  entrypoint: /bin/bash
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   - SINGLE_COMMAND=true
-  args: [
-    '/go/bin/cbctl', '-project=$PROJECT_ID',
-                     '-repo=switch-config',
-                     '-trigger_name=switch-config',
-                     '-github_token=$$GITHUB_TOKEN',
-                     '-branch=master',
-                     'trigger'
-  ]
+  args:
+  - '-c',
+  - |
+    /go/bin/cbif
+    /go/bin/cbctl -project=$PROJECT_ID
+                  -repo=switch-config
+                  -trigger_name=switch-config
+                  -github_token=$$GITHUB_TOKEN
+                  -branch=master
+                  trigger
   secretEnv:
   - GITHUB_TOKEN
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -136,6 +136,8 @@ steps:
                      '-branch=master',
                      'trigger'
   ]
+  secretEnv:
+  - GITHUB_TOKEN_${PROJECT_ID}
 
 # Deploy the primary measurement-lab.org zone to Cloud DNS.
 - name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
This PR introduces the use of a secret from the GCP Secret Manager into the Cloud Build for this repo. This allows `cbctl trigger` to use an authenticated Github client when triggering builds for private repositories, which is currently only the switch-config repo. Instructions on how to create the secret in Secret Manager is included in the README.md update in this PR.

NOTE: The build step for triggering a build in the switch-config repository is necessarily ugly. For some reason the [officially documented and supported way](https://cloud.google.com/build/docs/securing-builds/use-secrets) to use secrets from the Secret Manager in the build _requires_ you to use an `entrypoint` of /bin/bash (or at least some shell?). This seems very hackish, and it's unclear to me why this would be officially supported. In any case, it is what it is.

NOTE: Use of [built-in substitution variables](https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values) in the `availableSecrets` field of the YAML config does not appear to be documented, but seems to work:

> Use substitutions in your build's steps and images to resolve their values at build time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/189)
<!-- Reviewable:end -->
