### PR TITLE
Adds -n flag to echo in documentation for adding secrets to Secret Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Manager](https://cloud.google.com/build/docs/securing-builds/use-secrets). The
 secret can be created with this command:
 
 ```lang-sh
-echo <token> | gcloud secrets create siteinfo-builds-github-token --data-file=- --project <project>
+echo -n "<token>" | gcloud secrets create siteinfo-builds-github-token --data-file=- --project <project>
 ```
 
 You will then need to make sure that the Cloud Build service account for the
@@ -68,8 +68,8 @@ you can run:
 
 ```lang-sh
 gcloud secrets add-iam-policy-binding siteinfo-builds-github-token \
-      --member 'serviceAccount:<service-account>'
-      --role 'roles/secretmanager.secretAccessor'
+      --member 'serviceAccount:<service-account>' \
+      --role 'roles/secretmanager.secretAccessor' \
       --project <project>
 ```
 


### PR DESCRIPTION
The current documentation, if followed, will cause a newline to be appended to the secret in Secret Manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/190)
<!-- Reviewable:end -->
