### PR TITLE
Adds build step to sync ePoxy Datastore entities to sites in this repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -158,3 +158,12 @@ steps:
   - 'PROJECT=${PROJECT_ID}'
   - 'DOMAIN=${PROJECT_ID}.measurement-lab.org'
   - 'ZONEFILE=${PROJECT_ID}.measurement-lab.org.zone'
+
+# Sync ePoxy Datastore entities with this repository.
+- name: gcr.io/${PROJECT_ID}/siteinfo-cbif
+  env:
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  - SINGLE_COMMAND=true
+  args: [
+    '/go/bin/epoxy_admin', 'sync', '-project=$PROJECT_ID'
+  ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -165,5 +165,5 @@ steps:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   - SINGLE_COMMAND=true
   args: [
-    '/go/bin/epoxy_admin', 'sync', '-project=$PROJECT_ID'
+    '/go/bin/epoxy_admin', 'sync', '--project=$PROJECT_ID'
   ]


### PR DESCRIPTION
Currently, adding ePoxy Host Datastore entities is a manual process. Not only is it a manual process, but an operator has to _remember_ to do it. If it is not done, nodes at a new site cannot boot, and this can sometimes cause delays new site deployments, especially if an operator is not available to help the install technician during the install. This PR adds a new build step to automate this process, leveraging the [new `sync` operation of the epoxy_admin tool](https://github.com/m-lab/epoxy/pull/101).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/191)
<!-- Reviewable:end -->
