### PR TITLE
Adds missing IPv6 prefix to bog05

### DIFF
--- a/sites/bog05.jsonnet
+++ b/sites/bog05.jsonnet
@@ -24,7 +24,7 @@ sitesDefault {
       prefix: '162.213.97.64/26',
     },
     ipv6+: {
-      prefix: null
+      prefix: '2800:870:400:1::/64',
     },
   },
   transit+: {


### PR DESCRIPTION
When this site was first being deployed, there was confusion about both the IPv4 and IPv6 prefixes. Somehow, the IPv6 prefix for this site never got entered.  This PR resolves that oversight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/196)
<!-- Reviewable:end -->
