### PR TITLE
Adds new 'ipv6' label to BBE experiment scrape targets

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -338,8 +338,8 @@ def select_prometheus_experiment_targets(sites, project, select_regex,
             for experiment in node['experiments']:
                 labels = common_labels.copy()
                 labels['experiment'] = experiment['name']
-                labels['ipv6'] = 'enabled' if experiment['v6'][
-                    'ip'] != "" else "disabled"
+                labels['ipv6'] = 'present' if experiment['v6'][
+                    'ip'] != "" else "missing"
                 labels['machine'] = node['hostname']
 
                 # Skip if rsync_only is true but the experiment has no modules.

--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -338,6 +338,8 @@ def select_prometheus_experiment_targets(sites, project, select_regex,
             for experiment in node['experiments']:
                 labels = common_labels.copy()
                 labels['experiment'] = experiment['name']
+                labels['ipv6'] = 'enabled' if experiment['v6'][
+                    'ip'] != "" else "disabled"
                 labels['machine'] = node['hostname']
 
                 # Skip if rsync_only is true but the experiment has no modules.

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -209,7 +209,7 @@ class MlabconfigTest(unittest.TestCase):
             {
                 'labels': {
                     'experiment': 'bar.abc',
-                    'ipv6': 'enabled',
+                    'ipv6': 'present',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [
@@ -231,7 +231,7 @@ class MlabconfigTest(unittest.TestCase):
             {
                 'labels': {
                     'experiment': 'bar.abc',
-                    'ipv6': 'disabled',
+                    'ipv6': 'missing',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [
@@ -256,7 +256,7 @@ class MlabconfigTest(unittest.TestCase):
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
                     'experiment': 'bar.abc',
-                    'ipv6': 'enabled'
+                    'ipv6': 'present'
                 },
                 'targets': [
                     'bar.abc.mlab1.abc01.measurement-lab.org:9090'
@@ -277,7 +277,7 @@ class MlabconfigTest(unittest.TestCase):
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
                     'experiment': 'bar.abc',
-                    'ipv6': 'enabled'
+                    'ipv6': 'present'
                 },
                 'targets': [
                     'bar-abc-mlab1-abc01.measurement-lab.org:9090'

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -209,6 +209,7 @@ class MlabconfigTest(unittest.TestCase):
             {
                 'labels': {
                     'experiment': 'bar.abc',
+                    'ipv6': 'enabled',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [
@@ -224,12 +225,38 @@ class MlabconfigTest(unittest.TestCase):
         self.assertEqual(len(actual_targets), 1)
         self.assertCountEqual(expected_targets, actual_targets)
 
+    def test_select_prometheus_experiment_targets_ipv6_disabled(
+        self):
+        expected_targets = [
+            {
+                'labels': {
+                    'experiment': 'bar.abc',
+                    'ipv6': 'disabled',
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'bar.abc.mlab1.abc01.measurement-lab.org:9090'
+                ]
+            },
+        ]
+
+        sites_ipv6_disabled = sites
+        sites_ipv6_disabled[0]['nodes'][0]['experiments'][0]['v6']['ip'] = ""
+
+        actual_targets = mlabconfig.select_prometheus_experiment_targets(
+            self.sites, 'mlab-sandbox', None, ['{{hostname}}:9090'], {}, False, False, '',
+            False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertCountEqual(expected_targets, actual_targets)
+
     def test_select_prometheus_experiment_targets_includes_selected(self):
         expected_targets = [
             {
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
-                    'experiment': 'bar.abc'
+                    'experiment': 'bar.abc',
+                    'ipv6': 'enabled'
                 },
                 'targets': [
                     'bar.abc.mlab1.abc01.measurement-lab.org:9090'
@@ -249,7 +276,8 @@ class MlabconfigTest(unittest.TestCase):
             {
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
-                    'experiment': 'bar.abc'
+                    'experiment': 'bar.abc',
+                    'ipv6': 'enabled'
                 },
                 'targets': [
                     'bar-abc-mlab1-abc01.measurement-lab.org:9090'
@@ -269,7 +297,8 @@ class MlabconfigTest(unittest.TestCase):
             {
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
-                    'experiment': 'bar.abc'
+                    'experiment': 'bar.abc',
+                    'ipv6': 'enabled'
                 },
                 'targets': [
                     'bar.abc.mlab1v4.abc01.measurement-lab.org:9090'

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -298,7 +298,7 @@ class MlabconfigTest(unittest.TestCase):
                 'labels': {
                     'machine': 'mlab1.abc01.measurement-lab.org',
                     'experiment': 'bar.abc',
-                    'ipv6': 'enabled'
+                    'ipv6': 'present'
                 },
                 'targets': [
                     'bar.abc.mlab1v4.abc01.measurement-lab.org:9090'


### PR DESCRIPTION
A very small handful of sites (3) do not support IPv6. We still need to scrape these targets with IPv6 so that we have an explicit IPv6 failure metric for the Locate Service. However, we also need alerting for when IPv6 at a site/machine has been down for too long. This new `ipv6` label will allow us to filter sites/machine that don't have IPv6 configurations from the list of sites/machines where IPv6 is legitimately down.  The two values possible values are:

* `ipv6="present"`
* `ipv6="missing"`

This PR is related to PR https://github.com/m-lab/prometheus-support/pull/836
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/197)
<!-- Reviewable:end -->
