### PR TITLE
Changes YYZ05 machine types to R630

### DIFF
--- a/sites/yyz05.jsonnet
+++ b/sites/yyz05.jsonnet
@@ -7,16 +7,16 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
-      model: 'r640',
+      model: 'r630',
     },
     mlab2+: {
-      model: 'r640',
+      model: 'r630',
     },
     mlab3+: {
-      model: 'r640',
+      model: 'r630',
     },
     mlab4+: {
-      model: 'r640',
+      model: 'r630',
     },
   },
   network+: {


### PR DESCRIPTION
YYZ05 was provisioned using the older hardware from YYZ02, which were
R630s. YYZ02 was the CIRA-hosted 1g HE site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/202)
<!-- Reviewable:end -->
