### PR TITLE
Retires site YYZ02

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -51,6 +51,7 @@ local retiredSites = {
   yul01: import 'sites/yul01.jsonnet',
   yyc01: import 'sites/yyc01.jsonnet',
   yyz01: import 'sites/yyz01.jsonnet',
+  yyz02: import 'sites/yyz02.jsonnet',
 };
 [
   local site = retiredSites[name];

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -180,7 +180,6 @@ local sites = {
   yvr04: import 'sites/yvr04.jsonnet',
   ywg01: import 'sites/ywg01.jsonnet',
   yyc02: import 'sites/yyc02.jsonnet',
-  yyz02: import 'sites/yyz02.jsonnet',
   yyz03: import 'sites/yyz03.jsonnet',
   yyz04: import 'sites/yyz04.jsonnet',
   yyz05: import 'sites/yyz05.jsonnet',

--- a/sites/yyz02.jsonnet
+++ b/sites/yyz02.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2021-09-08',
   },
 }


### PR DESCRIPTION
YYZ02 equipment (old CIRA 1g HE site) was used to provision a new 10g Telia site YYZ05.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/203)
<!-- Reviewable:end -->
