### PR TITLE
Add "ipv6 " label to node blackbox_exporter targets

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -402,6 +402,7 @@ def select_prometheus_node_targets(sites, project, select_regex, target_template
                 continue
             labels = common_labels.copy()
             labels['machine'] = node['hostname']
+            labels['ipv6'] = 'present' if node['v6']['ip'] != "" else "missing"
             targets = []
 
             prefix = node['hostname'][:5]

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -244,11 +244,12 @@ class MlabconfigTest(unittest.TestCase):
         sites_ipv6_disabled[0]['nodes'][0]['experiments'][0]['v6']['ip'] = ""
 
         actual_targets = mlabconfig.select_prometheus_experiment_targets(
-            self.sites, 'mlab-sandbox', None, ['{{hostname}}:9090'], {}, False, False, '',
-            False)
+            sites_ipv6_disabled, 'mlab-sandbox', None, ['{{hostname}}:9090'],
+            {}, False, False, '', False)
 
         self.assertEqual(len(actual_targets), 1)
         self.assertCountEqual(expected_targets, actual_targets)
+        self.assertEqual(actual_targets[0]['labels']['ipv6'], "missing")
 
     def test_select_prometheus_experiment_targets_includes_selected(self):
         expected_targets = [

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -317,6 +317,7 @@ class MlabconfigTest(unittest.TestCase):
         expected_targets = [
             {
                 'labels': {
+                    'ipv6': 'present',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [
@@ -331,6 +332,30 @@ class MlabconfigTest(unittest.TestCase):
         self.assertEqual(len(actual_targets), 1)
         self.assertCountEqual(actual_targets, expected_targets)
 
+    def test_select_prometheus_node_targets_ipv6_disabled(self):
+        expected_targets = [
+            {
+                'labels': {
+                    'ipv6': 'missing',
+                    'machine': 'mlab1.abc01.measurement-lab.org'
+                },
+                'targets': [
+                    'mlab1.abc01.measurement-lab.org:9090'
+                ]
+            }
+        ]
+
+        sites_ipv6_disabled = sites
+        sites_ipv6_disabled[0]['nodes'][0]['v6']['ip'] = ""
+
+        actual_targets = mlabconfig.select_prometheus_node_targets(
+            sites_ipv6_disabled, "mlab-sandbox", "mlab1.*",
+            ['{{hostname}}:9090'], {}, '', False)
+
+        self.assertEqual(len(actual_targets), 1)
+        self.assertCountEqual(actual_targets, expected_targets)
+        self.assertEqual(actual_targets[0]['labels']['ipv6'], "missing")
+
     def test_select_prometheus_node_targets_excludes_unselected_project(self):
         actual_targets = mlabconfig.select_prometheus_node_targets(
             self.sites, "mlab-oti", "mlab1.*", ['{{hostname}}:9090'], {}, '', False)
@@ -341,6 +366,7 @@ class MlabconfigTest(unittest.TestCase):
         expected_targets = [
             {
                 'labels': {
+                    'ipv6': 'present',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [
@@ -359,6 +385,7 @@ class MlabconfigTest(unittest.TestCase):
         expected_targets = [
             {
                 'labels': {
+                    'ipv6': 'present',
                     'machine': 'mlab1.abc01.measurement-lab.org'
                 },
                 'targets': [


### PR DESCRIPTION
We already have an `ipv6` label on experiment targets, which indicates whether the site supports IPv6 or not. This PR does the same for node targets. We have SSH over IPv6 targets, and in order to be able to check whether they are working correctly, we need to be able to filter out sites that don't support IPv6 to begin with.

This PR also fixes a small bug the unit test for testing the ipv6 label for experiment targets.