### PR TITLE
Remove build trigger for epoxy-images-stage3

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -107,19 +107,6 @@ steps:
                      'trigger'
   ]
 
-# Trigger an epoxy-images stage3 build, which will build stage3 boot images for
-# any new sites.
-- name: gcr.io/${PROJECT_ID}/siteinfo-cbif
-  env:
-  - PROJECT_IN=mlab-staging,mlab-oti
-  - SINGLE_COMMAND=true
-  args: [
-    '/go/bin/cbctl', '-project=$PROJECT_ID',
-                     '-repo=epoxy-images',
-                     '-trigger_name=epoxy-images-stage3',
-                     'trigger'
-  ]
-
 # Trigger a switch-config build, which will build switch configurations for any
 # new sites, and deploy them to GCS.
 - name: gcr.io/${PROJECT_ID}/siteinfo-cbif


### PR DESCRIPTION
The stage 3 image is the same for every node, and does not need to be rebuilt on every change to this repository. This _should_ mean that the stage3 image will only get built a single time, when the epoxy-images repository is tagged, creating a new image version. I believe this change will make it safe to include package upgrades in the stage3 build and have a controlled deployment of the updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/214)
<!-- Reviewable:end -->
