### PR TITLE
Adds new cloud NDT sites chs0t and pdx0t

### DIFF
--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -21,22 +21,6 @@ CLOUDDNS_NORMALIZED="/workspace/clouddns.normalized"
 apt update
 apt install -y jq
 
-# The v2 zone for measurement-lab.org does not contain experiment records. All
-# experiment records are in the project subdomain zones, so do not run this
-# test unless this is a project subdomain.
-if [[ "${DOMAIN}" != "measurement-lab.org" ]]; then
-  # Make sure that every experiment has the same number of RRs.
-  UNIQ_EXP_RR_COUNTS=$(
-    grep -oP '^([a-z.-]+)[.-]mlab(?=[1-4])' "${SITEINFO_ZONE}" \
-      | sort | uniq -c | awk '{print $1}' | uniq
-  )
-  UNIQ_EXP_RR_COUNT=$(echo "${UNIQ_EXP_RR_COUNTS}" | wc -w)
-  if [[ "${UNIQ_EXP_RR_COUNT}" -ne "1" ]]; then
-    echo "Not all experiments have the same number of RRs."
-    exit 1
-  fi
-fi
-
 # Make sure that every switch in switches.json has a corresponding s1.* RR in the
 # generated zone file.
 SITE_COUNT=$(jq '. | length' /workspace/output/v1/sites/switches.json)

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -189,6 +189,7 @@ local sites = {
   yyz06: import 'sites/yyz06.jsonnet',
 
   // Test sites.
+  chs0t: import 'sites/chs0t.jsonnet',
   lga0t: import 'sites/lga0t.jsonnet',
   lga1t: import 'sites/lga1t.jsonnet',
   pdx0t: import 'sites/pdx0t.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -191,6 +191,7 @@ local sites = {
   // Test sites.
   lga0t: import 'sites/lga0t.jsonnet',
   lga1t: import 'sites/lga1t.jsonnet',
+  pdx0t: import 'sites/pdx0t.jsonnet',
 };
 [
   local site = sites[name];

--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -22,9 +22,9 @@ sitesDefault {
     },
   },
   transit+: {
-    provider: 'Google Cloud Platform',
+    provider: 'Google LLC',
     uplink: '10g',
-    asn: null,
+    asn: 'AS396982',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -1,0 +1,42 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'chs0t',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-sandbox',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.73.52.238/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google Cloud Platform',
+    uplink: '10g',
+    asn: null,
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'chs',
+    city: 'Charleston',
+    state: 'SC',
+    latitude: 32.8986,
+    longitude: -80.0406,
+  },
+  lifecycle+: {
+    created: '2022-01-14',
+  },
+}
+

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -22,9 +22,9 @@ sitesDefault {
     },
   },
   transit+: {
-    provider: 'Google Cloud Platform',
+    provider: 'Google LLC',
     uplink: '10g',
-    asn: null,
+    asn: 'AS15169',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'pdx0t',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+    disk: 'sda',
+    iface: 'eth0',
+    model: 'gce',
+    project: 'mlab-sandbox',
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.102.109.222/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google Cloud Platform',
+    uplink: '10g',
+    asn: 'AS0000',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'DE',
+    metro: 'fra',
+    city: 'Frankfurt',
+    state: '',
+    latitude: 50.0379,
+    longitude: 8.5622,
+  },
+  lifecycle+: {
+    created: '2022-01-12',
+  },
+}
+

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -7,10 +7,11 @@ sitesDefault {
   },
   machines: {
     mlab1: {
-    disk: 'sda',
-    iface: 'eth0',
-    model: 'gce',
-    project: 'mlab-sandbox',
+      disk: 'sda',
+      iface: 'eth0',
+      model: 'gce',
+      project: 'mlab-sandbox',
+    },
   },
   network+: {
     ipv4+: {

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -8,7 +8,7 @@ sitesDefault {
   machines: {
     mlab1: {
       disk: 'sda',
-      iface: 'eth0',
+      iface: 'ens4',
       model: 'gce',
       project: 'mlab-sandbox',
     },

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
   },
   network+: {
     ipv4+: {
-      prefix: '34.102.109.222/32',
+      prefix: '35.247.89.22/32',
     },
     ipv6+: {
       prefix: null,
@@ -24,19 +24,19 @@ sitesDefault {
   transit+: {
     provider: 'Google Cloud Platform',
     uplink: '10g',
-    asn: 'AS0000',
+    asn: null,
   },
   location+: {
-    continent_code: 'EU',
-    country_code: 'DE',
-    metro: 'fra',
-    city: 'Frankfurt',
-    state: '',
-    latitude: 50.0379,
-    longitude: 8.5622,
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'pdx',
+    city: 'Portland',
+    state: 'OR',
+    latitude: 45.5886,
+    longitude: -122.5975,
   },
   lifecycle+: {
-    created: '2022-01-12',
+    created: '2022-01-14',
   },
 }
 


### PR DESCRIPTION
CHS0T is located in Moncks Corner, SC
PDX0T is located in Dalles, OR

I had to make a change to the DNS deployment script to allow builds for this repo to work with NDT cloud sites. There was previously a very loose check to be sure that every experiment had the same number or DNS resource records, to check for any massive and obvious failure in the generation of the zone file. However, that check would fail with NDT cloud nodes, because resource records are only added for NDT, not other experiments, causing the RR counts to be different for each experiment, causing the build to fail. This PR just removes that check, since it was of questionable utility to being with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/215)
<!-- Reviewable:end -->
