### PR TITLE
Configures virtual sites pdx0t/chs01 as 1g

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -23,7 +23,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Google LLC',
-    uplink: '10g',
+    uplink: '1g',
     asn: 'AS396982',
   },
   location+: {

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -23,7 +23,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Google LLC',
-    uplink: '10g',
+    uplink: '1g',
     asn: 'AS15169',
   },
   location+: {


### PR DESCRIPTION
We are going to start our more conservative for virtual/cloud nodes/sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/220)
<!-- Reviewable:end -->
