### PR TITLE
Adds new "max-rates" v2 format

### DIFF
--- a/formats/v2/sites/max-rates.json.jsonnet
+++ b/formats/v2/sites/max-rates.json.jsonnet
@@ -1,0 +1,23 @@
+local sites = import 'sites.jsonnet';
+
+/*
+The max-rate for the -txcontroller.max-rate flag for ndt-server for 1Gbit/s
+sites is set to 150Mbit/s, which should mean that the combined throughput for a
+a site should not exceed 450Mbit/s, notwithstanding already running tests which
+may significantly exceed this number.
+*/
+local MaxRate1g = 150000000;
+
+/*
+The max-rate for the -txcontroller.max-rate flag for ndt-server for 10Gbit/s
+sites is set to 2.5Gbit/s, which should mean that the combined throughput for a
+a site should not exceed 7.5Gbit/s, notwithstanding already running tests which
+may significantly exceed this number.
+*/
+local MaxRate10g = 2500000000;
+
+{
+  [site.name]: if site.transit.uplink == '1g' then MaxRate1g else MaxRate10g
+  for site in sites
+}
+

--- a/formats/v2/sites/uplinks.json.jsonnet
+++ b/formats/v2/sites/uplinks.json.jsonnet
@@ -1,7 +1,0 @@
-local sites = import 'sites.jsonnet';
-
-{
-  [site.name]: site.transit.uplink,
-  for site in sites
-}
-

--- a/formats/v2/sites/uplinks.json.jsonnet
+++ b/formats/v2/sites/uplinks.json.jsonnet
@@ -1,0 +1,7 @@
+local sites = import 'sites.jsonnet';
+
+{
+  [site.name]: site.transit.uplink,
+  for site in sites
+}
+


### PR DESCRIPTION
The format will ultimately be used to populate the value of the ndt-server flag `-txcontroller.max-rate`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/221)
<!-- Reviewable:end -->
