### PR TITLE
Adds 10 new production GCE virtual sites

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -165,6 +165,7 @@ local sites = {
   sea04: import 'sites/sea04.jsonnet',
   sea07: import 'sites/sea07.jsonnet',
   sea08: import 'sites/sea08.jsonnet',
+  sea09: import 'sites/sea09.jsonnet',
   sin01: import 'sites/sin01.jsonnet',
   svg01: import 'sites/svg01.jsonnet',
   syd02: import 'sites/syd02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -83,6 +83,7 @@ local sites = {
   lax04: import 'sites/lax04.jsonnet',
   lax05: import 'sites/lax05.jsonnet',
   lax06: import 'sites/lax06.jsonnet',
+  lax07: import 'sites/lax07.jsonnet',
   lga04: import 'sites/lga04.jsonnet',
   lga05: import 'sites/lga05.jsonnet',
   lga06: import 'sites/lga06.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -76,6 +76,7 @@ local sites = {
   iad04: import 'sites/iad04.jsonnet',
   iad05: import 'sites/iad05.jsonnet',
   iad06: import 'sites/iad06.jsonnet',
+  iad07: import 'sites/iad07.jsonnet',
   jnb01: import 'sites/jnb01.jsonnet',
   lax02: import 'sites/lax02.jsonnet',
   lax03: import 'sites/lax03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -178,6 +178,7 @@ local sites = {
   tgd01: import 'sites/tgd01.jsonnet',
   tnr01: import 'sites/tnr01.jsonnet',
   tpe01: import 'sites/tpe01.jsonnet',
+  tpe02: import 'sites/tpe02.jsonnet',
   trn02: import 'sites/trn02.jsonnet',
   tun01: import 'sites/tun01.jsonnet',
   wlg02: import 'sites/wlg02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -30,6 +30,7 @@ local sites = {
   bru03: import 'sites/bru03.jsonnet',
   bru04: import 'sites/bru04.jsonnet',
   bru05: import 'sites/bru05.jsonnet',
+  bru06: import 'sites/bru06.jsonnet',
   cpt01: import 'sites/cpt01.jsonnet',
   del01: import 'sites/del01.jsonnet',
   del02: import 'sites/del02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -172,6 +172,7 @@ local sites = {
   sea08: import 'sites/sea08.jsonnet',
   sea09: import 'sites/sea09.jsonnet',
   sin01: import 'sites/sin01.jsonnet',
+  sin02: import 'sites/sin02.jsonnet',
   svg01: import 'sites/svg01.jsonnet',
   syd02: import 'sites/syd02.jsonnet',
   syd03: import 'sites/syd03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -96,6 +96,7 @@ local sites = {
   lhr05: import 'sites/lhr05.jsonnet',
   lhr07: import 'sites/lhr07.jsonnet',
   lhr08: import 'sites/lhr08.jsonnet',
+  lhr09: import 'sites/lhr09.jsonnet',
   lim01: import 'sites/lim01.jsonnet',
   lim02: import 'sites/lim02.jsonnet',
   lim03: import 'sites/lim03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -142,6 +142,7 @@ local sites = {
   ord04: import 'sites/ord04.jsonnet',
   ord05: import 'sites/ord05.jsonnet',
   ord06: import 'sites/ord06.jsonnet',
+  ord07: import 'sites/ord07.jsonnet',
   par02: import 'sites/par02.jsonnet',
   par03: import 'sites/par03.jsonnet',
   par04: import 'sites/par04.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -31,6 +31,7 @@ local sites = {
   bru04: import 'sites/bru04.jsonnet',
   bru05: import 'sites/bru05.jsonnet',
   bru06: import 'sites/bru06.jsonnet',
+  cgk01: import 'sites/cgk01.jsonnet',
   cpt01: import 'sites/cpt01.jsonnet',
   del01: import 'sites/del01.jsonnet',
   del02: import 'sites/del02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -55,6 +55,7 @@ local sites = {
   fra04: import 'sites/fra04.jsonnet',
   fra05: import 'sites/fra05.jsonnet',
   fra06: import 'sites/fra06.jsonnet',
+  fra07: import 'sites/fra07.jsonnet',
   gig01: import 'sites/gig01.jsonnet',
   gig02: import 'sites/gig02.jsonnet',
   gig03: import 'sites/gig03.jsonnet',

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -3,8 +3,8 @@ local site = import 'lib/site.jsonnet';
 site {
   name: error 'Must override site name',
   annotations: {
-    type: error 'Must override annotations.type, e.g. physical, virtual',
     provider: 'mlab',
+    type: error 'Must override annotations.type, e.g. physical, virtual',
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -3,7 +3,8 @@ local site = import 'lib/site.jsonnet';
 site {
   name: error 'Must override site name',
   annotations: {
-    type: error 'Must override annotations.type, e.g. physical, cloud',
+    type: error 'Must override annotations.type, e.g. physical, virtual',
+    provider: 'mlab',
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/bru06.jsonnet
+++ b/sites/bru06.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'bru06',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.79.58.167/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS15169',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'BE',
+    metro: 'bru',
+    city: 'Brussels',
+    state: '',
+    latitude: 50.4974,
+    longitude: 3.3528,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/bru06.jsonnet
+++ b/sites/bru06.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'bru06',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/cgk01.jsonnet
+++ b/sites/cgk01.jsonnet
@@ -1,0 +1,42 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'cgk01',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.101.131.175/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS139190',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'ID',
+    metro: 'cgk',
+    city: 'Jakarta',
+    state: '',
+    latitude: -6.1256,
+    longitude: 106.6558,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}
+

--- a/sites/cgk01.jsonnet
+++ b/sites/cgk01.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'cgk01',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'chs0t',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-sandbox',
     },
   },

--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'fra07',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.159.159.206/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'DE',
+    metro: 'fra',
+    city: 'Frankfurt',
+    state: '',
+    latitude: 50.0379,
+    longitude: 8.5622,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'fra07',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/iad07.jsonnet
+++ b/sites/iad07.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'iad07',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.85.166.60/32',
+    },
+    ipv6+: {
+      prefix: null
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'iad',
+    city: 'Washington',
+    state: 'DC',
+    latitude: 38.9444,
+    longitude: -77.4558,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/iad07.jsonnet
+++ b/sites/iad07.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'iad07',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/lax07.jsonnet
+++ b/sites/lax07.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'lax07',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/lax07.jsonnet
+++ b/sites/lax07.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'lax07',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.102.13.15/32',
+    },
+    ipv6+: {
+      prefix: '2600:1900:4120:30e8::/128',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'lax',
+    city: 'Los Angeles',
+    state: 'CA',
+    latitude: 33.9425,
+    longitude: -118.4072,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/lax0t.jsonnet
+++ b/sites/lax0t.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'lax0t',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-sandbox',
     },
   },

--- a/sites/lhr09.jsonnet
+++ b/sites/lhr09.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'lhr09',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '35.189.86.149/32',
+    },
+    ipv6+: {
+      prefix: '2600:1900:40c0:f08e::/128',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS15169',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'GB',
+    metro: 'lhr',
+    city: 'London',
+    state: '',
+    latitude: 51.4697,
+    longitude: -0.4514,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/lhr09.jsonnet
+++ b/sites/lhr09.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'lhr09',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'ord07',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'ord07',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '35.226.8.239/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'ord',
+    city: 'Chicago',
+    state: 'IL',
+    latitude: 41.9786,
+    longitude: -87.9047,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -24,7 +24,7 @@ sitesDefault {
   transit+: {
     provider: 'Google LLC',
     uplink: '1g',
-    asn: 'AS396982',
+    asn: 'AS15169',
   },
   location+: {
     continent_code: 'NA',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'pdx0t',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-sandbox',
     },
   },

--- a/sites/sea09.jsonnet
+++ b/sites/sea09.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'sea09',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.105.122.11/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'sea',
+    city: 'Seattle',
+    state: 'WA',
+    latitude: 47.4489,
+    longitude: -122.3094,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/sea09.jsonnet
+++ b/sites/sea09.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'sea09',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/sin02.jsonnet
+++ b/sites/sin02.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'sin02',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/sin02.jsonnet
+++ b/sites/sin02.jsonnet
@@ -1,0 +1,41 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'sin02',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '34.124.169.175/32',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS15169',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'SG',
+    metro: 'sin',
+    city: 'Singapore',
+    state: '',
+    latitude: 1.355,
+    longitude: 103.988,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}

--- a/sites/tpe02.jsonnet
+++ b/sites/tpe02.jsonnet
@@ -4,12 +4,13 @@ sitesDefault {
   name: 'tpe02',
   annotations+: {
     type: 'virtual',
+    provider: 'gcp',
   },
   machines: {
     mlab1: {
       disk: 'sda',
       iface: 'ens4',
-      model: 'gce',
+      model: 'n1-highcpu-4',
       project: 'mlab-oti',
     },
   },

--- a/sites/tpe02.jsonnet
+++ b/sites/tpe02.jsonnet
@@ -1,0 +1,42 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'tpe02',
+  annotations+: {
+    type: 'virtual',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'ens4',
+      model: 'gce',
+      project: 'mlab-oti',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '35.194.150.141/32',
+    },
+    ipv6+: {
+      prefix: '2600:1900:4030:ddef::/128',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'TW',
+    metro: 'tpe',
+    city: 'Taipei',
+    state: '',
+    latitude: 25.0778,
+    longitude: 121.224,
+  },
+  lifecycle+: {
+    created: '2022-03-02',
+  },
+}
+


### PR DESCRIPTION
This PR adds 11 new production (mlab-oti) GCE virtual sites, as specified in the "[Fast Canary](https://docs.google.com/document/d/1O2XGMZu7lEQ0wC8WVd0HnC8MZFLQatv2TbnX5YCrc1c/edit#heading=h.99veqx62rc8w)" section of the "To the cloud" document.

Except for CGK01 (Jakarta), all site files are copies of existing sites in their respective metros, meaning that all of the location data should be equal to whatever we already use for that metro. 

Three of these new virtual sites are IPv6 enabled: LAX07, LHR09, TPE02.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/224)
<!-- Reviewable:end -->
