### PR TITLE
Adds new virtual site library and default site template

### DIFF
--- a/lib/site_virtual.jsonnet
+++ b/lib/site_virtual.jsonnet
@@ -1,0 +1,93 @@
+local version = std.extVar('version');
+
+{
+  // Returns the appropriate base domain depending on the node project for v2
+  // outputs, else just the standard base domain.
+  BaseDomain(m):: (
+    local domainMap = {
+      'mlab-sandbox': 'mlab-sandbox.measurement-lab.org',
+      'mlab-staging': 'mlab-staging.measurement-lab.org',
+      'mlab-oti': 'mlab-oti.measurement-lab.org',
+    };
+    if version == 'v2' then
+      '%s' % domainMap[$.machines['mlab' + m].project]
+    else
+      'measurement-lab.org'
+  ),
+  // Extracts the integer machine index from the string machine name m.
+  MachineIndex(m):: (
+    local i = std.parseInt(std.substr(m, 4, 1));
+    i
+  ),
+  // Virtual sites do not have prefixes. Instead, each machine has it's own
+  // specific network configuration. These functions just return an empty string
+  // for formats that assume every site has a prefix.
+  V4Prefix():: '',
+  V6Prefix():: '',
+  // Machine returns a network spec for virtual machine m. The decoration
+  // parameter may be used to decorate the machine record and hostname.
+  Machine(m):: {
+    local i = $.MachineIndex(m),
+    local v4addr = $.machines['mlab' + i].network.ipv4.address,
+    local v6addr = $.machines['mlab' + i].network.ipv6.address,
+    index: i,
+    project: $.machines['mlab' + i].project,
+    v4: {
+      ip: std.split($.machines['mlab' + i].network.ipv4.address, '/')[0],
+    },
+    v6: {
+      ip: (
+        if v6addr == null then '' else (
+          std.split($.machines['mlab' + i].network.ipv6.address, '/')[0]
+        )
+      ),
+    },
+    // Returns the network configuration for machine m.
+    Network():: {
+      Network: {
+        IPv4: v4addr,
+        IPv6: if v6addr != null then v6addr else '',
+      },
+    },
+    // Record returns a machine name suitable for a zone record including the
+    // decoration if given.
+    Record(decoration=''):: (
+      if version == 'v1' then
+        'mlab%s%s.%s' % [i, decoration, $.name]
+      else
+        'mlab%s%s-%s' % [i, decoration, $.name]
+    ),
+    // Hostname returns a machine FQDN including the decoration, if given.
+    Hostname(decoration=''):: '%s.%s' % [self.Record(decoration), $.BaseDomain(i)],
+  },
+  // Experiment returns a network spec for the given experiment config on
+  // machine m.
+  Experiment(m, expConfig):: if expConfig.cloud_enabled then expConfig {
+    local i = $.MachineIndex(m),
+    local v4addr = $.machines['mlab' + i].network.ipv4.address,
+    local v6addr = $.machines['mlab' + i].network.ipv6.address,
+    v4: {
+      ip: std.split($.machines['mlab' + i].network.ipv4.address, '/')[0],
+    },
+    v6: {
+      ip: (
+        if v6addr == null then '' else (
+          std.split($.machines['mlab' + i].network.ipv6.address, '/')[0]
+        )
+      ),
+    },
+    hostname: self.Hostname(),
+    // Record returns a machine name suitable for a zone record including the
+    // decoration if given.
+    Record(decoration=''):: (
+      // For v1 zones we include dotted and dashed/flat hostnames. For anything
+      // later than v1 we only include dashed/flat names.
+      if version == 'v1' then
+        '%s.mlab%d%s.%s' % [expConfig.name, i, decoration, $.name]
+      else
+        '%s-mlab%d%s-%s' % [std.strReplace(expConfig.name, '.', '-'), i, decoration, $.name]
+    ),
+    // Hostname returns a machine FQDN including the decoration, if given.
+    Hostname(decoration=''):: '%s.%s' % [self.Record(decoration), $.BaseDomain(i)],
+  },
+}

--- a/lib/site_virtual.jsonnet
+++ b/lib/site_virtual.jsonnet
@@ -20,12 +20,10 @@ local version = std.extVar('version');
     i
   ),
   // Virtual sites do not have prefixes. Instead, each machine has it's own
-  // specific network configuration. These functions just return an empty string
-  // for formats that assume every site has a prefix.
-  V4Prefix():: '',
-  V6Prefix():: '',
-  // Machine returns a network spec for virtual machine m. The decoration
-  // parameter may be used to decorate the machine record and hostname.
+  // specific network configuration. This functions just return an empty string
+  // for both IPv4 and IPv6 formats that assume every site has a prefix.
+  NetworkPrefix(proto):: '',
+  // Machine returns a network spec for virtual machine m.
   Machine(m):: {
     local i = $.MachineIndex(m),
     local v4addr = $.machines['mlab' + i].network.ipv4.address,

--- a/lib/site_virtual_test.jsonnet
+++ b/lib/site_virtual_test.jsonnet
@@ -1,0 +1,164 @@
+local test = import 'jsonnetunit/test.libsonnet';
+local defaultSite = import 'sites/_default_virtual.jsonnet';
+local version = std.extVar('version');
+
+// A v4-only virtual site with 1 node
+local v4Site1Node = defaultSite {
+  name: 'mck0t',
+  annotations+: {
+    provider: 'gcp',
+    type: 'virtual',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '10.0.0.5/32',
+        },
+      },
+      project: 'mlab-sandbox',
+    },
+  },
+};
+// A v4-only virtual site with 2 nodes
+local v4Site2Nodes = defaultSite {
+  name: 'mck0t',
+  annotations+: {
+    provider: 'gcp',
+    type: 'virtual',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '10.0.0.22/32',
+        },
+      },
+      project: 'mlab-sandbox',
+    },
+    mlab3: {
+      disk: 'pd-standard',
+      iface: 'ens4',
+      model: 'e1-highcpu-6',
+      network: {
+        ipv4: {
+          address: '172.16.0.10/32',
+        },
+        ipv6: {
+          address: null,
+        },
+      },
+      project: 'mlab-sandbox',
+    },
+  },
+};
+// A dual stack virtual site with 2 nodes.
+local v4v6Site2Nodes = defaultSite {
+  name: 'mck0t',
+  annotations+: {
+    provider: 'gcp',
+    type: 'virtual',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '10.0.0.55/32',
+        },
+        ipv6+: {
+          address: '2600:1900:2100:2e::35/128',
+        },
+      },
+      project: 'mlab-sandbox',
+    },
+    mlab4: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n1-highcpu-4',
+      network: {
+        ipv4: {
+          address: '192.168.0.20/32',
+        },
+        ipv6: {
+          address: '2600:1900:54:e96::99/128',
+        },
+      },
+      project: 'mlab-sandbox',
+    },
+  },
+};
+
+test.suite({
+  test_v4_one_node: {
+    actual: [
+      v4Site1Node.Machine('mlab1').v4.ip,
+      v4Site1Node.MachineIndex('mlab1'),
+      v4Site1Node.V4Prefix(),
+      v4Site1Node.V6Prefix(),
+      v4Site1Node.Machine('mlab1').Record(),
+      v4Site1Node.Machine('mlab1').Record('v4'),
+      v4Site1Node.Machine('mlab1').Hostname(),
+      v4Site1Node.Machine('mlab1').Hostname('v4'),
+    ],
+    expect: [
+      '10.0.0.5',
+      1,
+      '',
+      '',
+      if version == 'v1' then 'mlab1.mck0t' else 'mlab1-mck0t',
+      if version == 'v1' then 'mlab1v4.mck0t' else 'mlab1v4-mck0t',
+      if version == 'v1' then 'mlab1.mck0t.measurement-lab.org' else 'mlab1-mck0t.mlab-sandbox.measurement-lab.org',
+      if version == 'v1' then 'mlab1v4.mck0t.measurement-lab.org' else 'mlab1v4-mck0t.mlab-sandbox.measurement-lab.org',
+    ],
+  },
+  test_v4_two_nodes: {
+    actual: [
+      v4Site2Nodes.Machine('mlab1').v4.ip,
+      v4Site2Nodes.Machine('mlab3').v4.ip,
+    ],
+    expect: [
+      '10.0.0.22',
+      '172.16.0.10',
+    ],
+  },
+  test_v4v6_two_nodes: {
+    actual: [
+      v4v6Site2Nodes.Machine('mlab1').v6.ip,
+      v4v6Site2Nodes.Machine('mlab4').v6.ip,
+    ],
+    expect: [
+      '2600:1900:2100:2e::35',
+      '2600:1900:54:e96::99',
+    ],
+  },
+  test_experiment: {
+    actual: [
+      v4Site1Node.Experiment('mlab1', { index: 1, name: 'fake.exp', cloud_enabled: true }).v4.ip,
+      v4Site2Nodes.Experiment('mlab3', { index: 1, name: 'fake.exp', cloud_enabled: true }).v4.ip,
+      v4v6Site2Nodes.Experiment('mlab1', { index: 1, name: 'fake.exp', cloud_enabled: true }).v6.ip,
+      v4v6Site2Nodes.Experiment('mlab1', { index: 1, name: 'fake.exp', cloud_enabled: false }),
+      v4v6Site2Nodes.Experiment('mlab4', { index: 1, name: 'fake.exp', cloud_enabled: true }).Record(),
+      v4v6Site2Nodes.Experiment('mlab1', { index: 1, name: 'fake.exp', cloud_enabled: true }).Record('v4'),
+      v4v6Site2Nodes.Experiment('mlab4', { index: 1, name: 'fake.exp', cloud_enabled: true }).Hostname(),
+      v4v6Site2Nodes.Experiment('mlab1', { index: 1, name: 'fake.exp', cloud_enabled: true }).Hostname('v6'),
+    ],
+    expect: [
+      '10.0.0.5',
+      '172.16.0.10',
+      '2600:1900:2100:2e::35',
+      null,
+      if version == 'v1' then 'fake.exp.mlab4.mck0t' else 'fake-exp-mlab4-mck0t',
+      if version == 'v1' then 'fake.exp.mlab1v4.mck0t' else 'fake-exp-mlab1v4-mck0t',
+      if version == 'v1' then 'fake.exp.mlab4.mck0t.measurement-lab.org' else 'fake-exp-mlab4-mck0t.mlab-sandbox.measurement-lab.org',
+      if version == 'v1' then 'fake.exp.mlab1v6.mck0t.measurement-lab.org' else 'fake-exp-mlab1v6-mck0t.mlab-sandbox.measurement-lab.org',
+    ],
+  },
+  test_machine_network: {
+    actual: [
+      v4v6Site2Nodes.Machine('mlab4').Network(),
+    ],
+    expect: [
+      { Network: { IPv4: '192.168.0.20/32', IPv6: '2600:1900:54:e96::99/128' } },
+    ],
+  },
+})

--- a/lib/site_virtual_test.jsonnet
+++ b/lib/site_virtual_test.jsonnet
@@ -93,8 +93,8 @@ test.suite({
     actual: [
       v4Site1Node.Machine('mlab1').v4.ip,
       v4Site1Node.MachineIndex('mlab1'),
-      v4Site1Node.V4Prefix(),
-      v4Site1Node.V6Prefix(),
+      v4Site1Node.NetworkPrefix('v4'),
+      v4Site1Node.NetworkPrefix('v6'),
       v4Site1Node.Machine('mlab1').Record(),
       v4Site1Node.Machine('mlab1').Record('v4'),
       v4Site1Node.Machine('mlab1').Hostname(),

--- a/sites/_default_virtual.jsonnet
+++ b/sites/_default_virtual.jsonnet
@@ -1,0 +1,47 @@
+local site = import 'lib/site_virtual.jsonnet';
+
+site {
+  name: error 'Must override site name',
+  annotations: {
+    provider: 'mlab',
+    type: 'virtual',
+  },
+  loadbalancer: {
+    roundrobin: true,
+  },
+  machines: {
+    mlab1: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n1-highcpu-4',
+      network: {
+        ipv4: {
+          address: error 'Must override IPv4 address',
+        },
+        ipv6: {
+          address: null,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit: {
+    provider: error 'Must override transit.provider',
+    uplink: error 'Must override transit.uplink',
+    asn: error 'Must override transit.asn',
+    tier: 'PREMIUM',
+  },
+  location: {
+    continent_code: error 'Must override location.continent_code',
+    country_code: error 'Must override location.country_code',
+    metro: error 'Must override location.metro',
+    city: error 'Must override location.city',
+    state: error 'Must override location.state',
+    latitude: error 'Must override location.latitude',
+    longitude: error 'Must override location.longitude',
+  },
+  lifecycle: {
+    created: error 'Must override lifecycle.created',
+    retired: null,
+  },
+}


### PR DESCRIPTION
This commit adds a new library and default site template for virtual sites. It also adds basic unit testing.

The new default virtual site template will be imported by virtual sites, and the virtual site template will import the new library file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/228)
<!-- Reviewable:end -->
