### PR TITLE
Uses FQDN for Name field in v2 annotations.json

### DIFF
--- a/formats/v2/sites/annotations.json.jsonnet
+++ b/formats/v2/sites/annotations.json.jsonnet
@@ -9,7 +9,7 @@ local parseASN(asn) = (
   {
     // NOTE: the uuid-annotator uses camel case in exported JSON, so the
     // following object keys are capitalized accordingly.
-    Name: site.name,
+    Name: site.Machine(machine).Hostname(),
     Type: site.annotations.type,
     // Network allows identifying individual connection CIDR values.
     Network: {
@@ -20,7 +20,7 @@ local parseASN(asn) = (
       local loc = site.location,
       local transit = site.transit,
       Site: site.name,
-      Machine: site.Machine(machine).Hostname(),
+      Machine: machine,
       Geo: {
         ContinentCode: loc.continent_code,
         CountryCode: loc.country_code,

--- a/formats/v2/sites/annotations.json.jsonnet
+++ b/formats/v2/sites/annotations.json.jsonnet
@@ -5,11 +5,10 @@ local parseASN(asn) = (
   else
     0
 );
-[
-  {
+{
+  [site.Machine(machine).Hostname()]: {
     // NOTE: the uuid-annotator uses camel case in exported JSON, so the
     // following object keys are capitalized accordingly.
-    Name: site.Machine(machine).Hostname(),
     Type: site.annotations.type,
     // Network allows identifying individual connection CIDR values.
     Network: {
@@ -45,4 +44,4 @@ local parseASN(asn) = (
   }
   for site in sites
   for machine in std.objectFields(site.machines)
-]
+}


### PR DESCRIPTION
The uuid-annotator uses the field Annotations.Machine to specify _only_
the machine (e.g., mlab1, mlab3, etc.) not the FQDN of the host. This
commit makes the field Name reflect the FQDN, and Annotations.Machine to
be only the machine at the site to be consitent with how the
uuid-annotator understands these terms/fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/233)
<!-- Reviewable:end -->
