### PR TITLE
Retires Vocus site SYD02

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -46,6 +46,7 @@ local retiredSites = {
   sea06: import 'sites/sea06.jsonnet',
   sjc01: import 'sites/sjc01.jsonnet',
   syd01: import 'sites/syd01.jsonnet',
+  syd02: import 'sites/syd02.jsonnet',
   trn01: import 'sites/trn01.jsonnet',
   vie01: import 'sites/vie01.jsonnet',
   wlg01: import 'sites/wlg01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -177,7 +177,6 @@ local sites = {
   sin02: import 'sites/sin02.jsonnet',
   sof01: import 'sites/sof01.jsonnet',
   svg01: import 'sites/svg01.jsonnet',
-  syd02: import 'sites/syd02.jsonnet',
   syd03: import 'sites/syd03.jsonnet',
   syd04: import 'sites/syd04.jsonnet',
   syd05: import 'sites/syd05.jsonnet',

--- a/sites/syd02.jsonnet
+++ b/sites/syd02.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2022-04-08',
   },
 }


### PR DESCRIPTION
SYD02 was somehow replaced by SYD05. The details are fuzzy:

https://github.com/m-lab/ops-tracker/issues/1563

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/236)
<!-- Reviewable:end -->
