### PR TITLE
Adds new format listing machine names at a site

### DIFF
--- a/formats/v2/sites/site-machines.json.jsonnet
+++ b/formats/v2/sites/site-machines.json.jsonnet
@@ -1,0 +1,6 @@
+local sites = import 'sites.jsonnet';
+
+{
+  [site.name]: std.objectFields(site.machines)
+  for site in sites
+}


### PR DESCRIPTION
For many years a lot of M-Lab code has made the assumption that a site
is comprised of 4 machine, with the mlab4 machine being a staging
machine. With the recent introduction of virtual ("cloud") sites that
may not have 4 nodes, the old logic no longer holds true. This new
format can be used by people or code to determine which machines (mlab1,
mlab3, etc.) exist at any given site, in a short and concise way. This
same information can be determined by using other, existing formats, but
those are fairly heavy weight.

The specific impetus for this new format is the Github Maintenance
Exporter, which needs to know which machines a site has so that each
machine can be properly put into maintenance mode when an entire site is
put into maintenance, without also putting non-existent machines into
maintenance mode also.