### PR TITLE
Fixes the machine and network config for virtual site oma01

### DIFF
--- a/sites/oma01.jsonnet
+++ b/sites/oma01.jsonnet
@@ -5,13 +5,16 @@ sitesDefault {
   annotations+: {
     provider: 'gcp',
   },
-  machines+: {
-    mlab4+: {
-      network+: {
-        ipv4+: {
+  machines: {
+    mlab4: {
+      disk: 'pd-standard',
+      iface: 'ens4',
+      model: 'n1-highcpu-4',
+      network: {
+        ipv4: {
           address: '104.197.205.150/32',
         },
-        ipv6+: {
+        ipv6: {
           address: '2600:1900:4000:bcb9::/128',
         },
       },

--- a/sites/oma01.jsonnet
+++ b/sites/oma01.jsonnet
@@ -6,7 +6,7 @@ sitesDefault {
     provider: 'gcp',
   },
   machines+: {
-    mlab1+: {
+    mlab4+: {
       network+: {
         ipv4+: {
           address: '104.197.205.150/32',


### PR DESCRIPTION
The machine name should have been mlab4, not mlab1, and the network config should be static, not extending the default template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/244)
<!-- Reviewable:end -->
