### PR TITLE
Adds 24 virtual sites in remaining GCP regions

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -33,6 +33,7 @@ local sites = {
   bru05: import 'sites/bru05.jsonnet',
   bru06: import 'sites/bru06.jsonnet',
   cgk01: import 'sites/cgk01.jsonnet',
+  chs01: import 'sites/chs01.jsonnet',
   cpt01: import 'sites/cpt01.jsonnet',
   del01: import 'sites/del01.jsonnet',
   del02: import 'sites/del02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -230,6 +230,7 @@ local sites = {
   yyz05: import 'sites/yyz05.jsonnet',
   yyz06: import 'sites/yyz06.jsonnet',
   yyz07: import 'sites/yyz07.jsonnet',
+  zrh01: import 'sites/zrh01.jsonnet',
 
   // Test sites.
   chs0t: import 'sites/chs0t.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -183,6 +183,7 @@ local sites = {
   scl02: import 'sites/scl02.jsonnet',
   scl03: import 'sites/scl03.jsonnet',
   scl04: import 'sites/scl04.jsonnet',
+  scl05: import 'sites/scl05.jsonnet',
   sea02: import 'sites/sea02.jsonnet',
   sea03: import 'sites/sea03.jsonnet',
   sea04: import 'sites/sea04.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -47,6 +47,7 @@ local sites = {
   dfw05: import 'sites/dfw05.jsonnet',
   dfw07: import 'sites/dfw07.jsonnet',
   dfw08: import 'sites/dfw08.jsonnet',
+  dfw09: import 'sites/dfw09.jsonnet',
   dub01: import 'sites/dub01.jsonnet',
   eze01: import 'sites/eze01.jsonnet',
   eze02: import 'sites/eze02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -89,6 +89,7 @@ local sites = {
   iad07: import 'sites/iad07.jsonnet',
   iad08: import 'sites/iad08.jsonnet',
   jnb01: import 'sites/jnb01.jsonnet',
+  kix01: import 'sites/kix01.jsonnet',
   las01: import 'sites/las01.jsonnet',
   lax02: import 'sites/lax02.jsonnet',
   lax03: import 'sites/lax03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -209,6 +209,7 @@ local sites = {
   yul04: import 'sites/yul04.jsonnet',
   yul05: import 'sites/yul05.jsonnet',
   yul06: import 'sites/yul06.jsonnet',
+  yul07: import 'sites/yul07.jsonnet',
   yvr01: import 'sites/yvr01.jsonnet',
   yvr02: import 'sites/yvr02.jsonnet',
   yvr03: import 'sites/yvr03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -34,6 +34,7 @@ local sites = {
   bru06: import 'sites/bru06.jsonnet',
   cgk01: import 'sites/cgk01.jsonnet',
   chs01: import 'sites/chs01.jsonnet',
+  cmh01: import 'sites/cmh01.jsonnet',
   cpt01: import 'sites/cpt01.jsonnet',
   del01: import 'sites/del01.jsonnet',
   del02: import 'sites/del02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -124,6 +124,7 @@ local sites = {
   mad03: import 'sites/mad03.jsonnet',
   mad04: import 'sites/mad04.jsonnet',
   mad06: import 'sites/mad06.jsonnet',
+  mad07: import 'sites/mad07.jsonnet',
   mex01: import 'sites/mex01.jsonnet',
   mex02: import 'sites/mex02.jsonnet',
   mex03: import 'sites/mex03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -202,6 +202,7 @@ local sites = {
   syd04: import 'sites/syd04.jsonnet',
   syd05: import 'sites/syd05.jsonnet',
   syd06: import 'sites/syd06.jsonnet',
+  syd07: import 'sites/syd07.jsonnet',
   tgd01: import 'sites/tgd01.jsonnet',
   tnr01: import 'sites/tnr01.jsonnet',
   tpe01: import 'sites/tpe01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -90,6 +90,7 @@ local sites = {
   iad06: import 'sites/iad06.jsonnet',
   iad07: import 'sites/iad07.jsonnet',
   iad08: import 'sites/iad08.jsonnet',
+  icn01: import 'sites/icn01.jsonnet',
   jnb01: import 'sites/jnb01.jsonnet',
   kix01: import 'sites/kix01.jsonnet',
   las01: import 'sites/las01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -38,6 +38,7 @@ local sites = {
   cpt01: import 'sites/cpt01.jsonnet',
   del01: import 'sites/del01.jsonnet',
   del02: import 'sites/del02.jsonnet',
+  del03: import 'sites/del03.jsonnet',
   den02: import 'sites/den02.jsonnet',
   den04: import 'sites/den04.jsonnet',
   den05: import 'sites/den05.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -89,6 +89,7 @@ local sites = {
   iad07: import 'sites/iad07.jsonnet',
   iad08: import 'sites/iad08.jsonnet',
   jnb01: import 'sites/jnb01.jsonnet',
+  las01: import 'sites/las01.jsonnet',
   lax02: import 'sites/lax02.jsonnet',
   lax03: import 'sites/lax03.jsonnet',
   lax04: import 'sites/lax04.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -228,6 +228,7 @@ local sites = {
   yyz04: import 'sites/yyz04.jsonnet',
   yyz05: import 'sites/yyz05.jsonnet',
   yyz06: import 'sites/yyz06.jsonnet',
+  yyz07: import 'sites/yyz07.jsonnet',
 
   // Test sites.
   chs0t: import 'sites/chs0t.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -125,6 +125,7 @@ local sites = {
   mad04: import 'sites/mad04.jsonnet',
   mad06: import 'sites/mad06.jsonnet',
   mad07: import 'sites/mad07.jsonnet',
+  mel01: import 'sites/mel01.jsonnet',
   mex01: import 'sites/mex01.jsonnet',
   mex02: import 'sites/mex02.jsonnet',
   mex03: import 'sites/mex03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -26,6 +26,7 @@ local sites = {
   bog05: import 'sites/bog05.jsonnet',
   bom01: import 'sites/bom01.jsonnet',
   bom02: import 'sites/bom02.jsonnet',
+  bom03: import 'sites/bom03.jsonnet',
   bru01: import 'sites/bru01.jsonnet',
   bru02: import 'sites/bru02.jsonnet',
   bru03: import 'sites/bru03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -82,6 +82,7 @@ local sites = {
   hnd03: import 'sites/hnd03.jsonnet',
   hnd04: import 'sites/hnd04.jsonnet',
   hnd05: import 'sites/hnd05.jsonnet',
+  hnd06: import 'sites/hnd06.jsonnet',
   hnl01: import 'sites/hnl01.jsonnet',
   iad02: import 'sites/iad02.jsonnet',
   iad03: import 'sites/iad03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -6,6 +6,7 @@ local sites = {
   ams05: import 'sites/ams05.jsonnet',
   ams08: import 'sites/ams08.jsonnet',
   ams09: import 'sites/ams09.jsonnet',
+  ams10: import 'sites/ams10.jsonnet',
   arn02: import 'sites/arn02.jsonnet',
   arn03: import 'sites/arn03.jsonnet',
   arn04: import 'sites/arn04.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -191,6 +191,7 @@ local sites = {
   sea09: import 'sites/sea09.jsonnet',
   sin01: import 'sites/sin01.jsonnet',
   sin02: import 'sites/sin02.jsonnet',
+  slc01: import 'sites/slc01.jsonnet',
   sof01: import 'sites/sof01.jsonnet',
   sof02: import 'sites/sof02.jsonnet',
   svg01: import 'sites/svg01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -71,6 +71,7 @@ local sites = {
   gru03: import 'sites/gru03.jsonnet',
   gru04: import 'sites/gru04.jsonnet',
   ham02: import 'sites/ham02.jsonnet',
+  hel01: import 'sites/hel01.jsonnet',
   hkg01: import 'sites/hkg01.jsonnet',
   hkg02: import 'sites/hkg02.jsonnet',
   hkg03: import 'sites/hkg03.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -210,6 +210,7 @@ local sites = {
   tpe02: import 'sites/tpe02.jsonnet',
   trn02: import 'sites/trn02.jsonnet',
   tun01: import 'sites/tun01.jsonnet',
+  waw01: import 'sites/waw01.jsonnet',
   wlg02: import 'sites/wlg02.jsonnet',
   yqm01: import 'sites/yqm01.jsonnet',
   yul02: import 'sites/yul02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -75,6 +75,7 @@ local sites = {
   hkg01: import 'sites/hkg01.jsonnet',
   hkg02: import 'sites/hkg02.jsonnet',
   hkg03: import 'sites/hkg03.jsonnet',
+  hkg04: import 'sites/hkg04.jsonnet',
   hnd02: import 'sites/hnd02.jsonnet',
   hnd03: import 'sites/hnd03.jsonnet',
   hnd04: import 'sites/hnd04.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -171,6 +171,7 @@ local sites = {
   par05: import 'sites/par05.jsonnet',
   par06: import 'sites/par06.jsonnet',
   par07: import 'sites/par07.jsonnet',
+  par08: import 'sites/par08.jsonnet',
   per01: import 'sites/per01.jsonnet',
   per02: import 'sites/per02.jsonnet',
   prg02: import 'sites/prg02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -141,6 +141,7 @@ local sites = {
   mil05: import 'sites/mil05.jsonnet',
   mil06: import 'sites/mil06.jsonnet',
   mil07: import 'sites/mil07.jsonnet',
+  mil08: import 'sites/mil08.jsonnet',
   mnl01: import 'sites/mnl01.jsonnet',
   mnl02: import 'sites/mnl02.jsonnet',
   mpm02: import 'sites/mpm02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -71,6 +71,7 @@ local sites = {
   gru02: import 'sites/gru02.jsonnet',
   gru03: import 'sites/gru03.jsonnet',
   gru04: import 'sites/gru04.jsonnet',
+  gru05: import 'sites/gru05.jsonnet',
   ham02: import 'sites/ham02.jsonnet',
   hel01: import 'sites/hel01.jsonnet',
   hkg01: import 'sites/hkg01.jsonnet',

--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'ams10',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.91.170.199/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4060:f014::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'NL',
+    metro: 'ams',
+    city: 'Amsterdam',
+    state: '',
+    latitude: 52.3086,
+    longitude: 4.7639,
+  },
+  lifecycle+: {
+    created: '2022-09-07',
+  },
+}

--- a/sites/bom03.jsonnet
+++ b/sites/bom03.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'bom03',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.93.189.150/32',
+        },
+        ipv6+: {
+          address: '2600:1900:40a0:f2f2::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'IN',
+    metro: 'bom',
+    city: 'Mumbai',
+    state: '',
+    latitude: 19.0886,
+    longitude: 72.8681,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/bru06.jsonnet
+++ b/sites/bru06.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '34.79.58.167/32',
         },
+        ipv6+: {
+          address: '2600:1900:4010:a6d4::/128',
+        },
       },  
       project: 'mlab-oti',
     },

--- a/sites/cgk01.jsonnet
+++ b/sites/cgk01.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '34.101.131.175/32',
         },
+        ipv6+: {
+          address: '2600:1901:8170:40d1::/128',
+        },
       },  
       project: 'mlab-oti',
     },

--- a/sites/chs01.jsonnet
+++ b/sites/chs01.jsonnet
@@ -1,7 +1,7 @@
 local sitesDefault = import 'sites/_default_virtual.jsonnet';
 
 sitesDefault {
-  name: 'lax07',
+  name: 'chs01',
   annotations+: {
     provider: 'gcp',
   },
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '34.102.13.15/32',
+          address: '34.139.106.82/32',
         },
         ipv6+: {
-          address: '2600:1900:4120:30e8:0:1::/128',
+          address: '2600:1900:4020:5b68::/128',
         },
       },
       project: 'mlab-oti',
@@ -26,13 +26,13 @@ sitesDefault {
   location+: {
     continent_code: 'NA',
     country_code: 'US',
-    metro: 'lax',
-    city: 'Los Angeles',
-    state: 'CA',
-    latitude: 33.9425,
-    longitude: -118.4072,
+    metro: 'chs',
+    city: 'Charleston',
+    state: 'SC',
+    latitude: 32.8986,
+    longitude: -80.0406,
   },
   lifecycle+: {
-    created: '2022-03-02',
+    created: '2022-09-07',
   },
 }

--- a/sites/cmh01.jsonnet
+++ b/sites/cmh01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'cmh01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.162.22.206/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8130:246c::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'cmh',
+    city: 'Columbus',
+    state: 'OH',
+    latitude: 39.9981,
+    longitude: -82.8919,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/del03.jsonnet
+++ b/sites/del03.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'del03',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.131.204.19/32',
+        },
+        ipv6+: {
+          address: '2600:1900:41b0:a72::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'IN',
+    metro: 'del',
+    city: 'New Delhi',
+    state: '',
+    latitude: 28.5562,
+    longitude: 77.1000,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'dfw09',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.174.167.116/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8140:9cd3::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'dfw',
+    city: 'Dallas',
+    state: 'TX',
+    latitude: 32.8969,
+    longitude: -97.0381,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -8,8 +8,11 @@ sitesDefault {
   machines+: {
     mlab1+: {
       network+: {
-        ipv4: {
+        ipv4+: {
           address: '34.159.159.206/32',
+        },
+        ipv6+: {
+          address: '2600:1900:40d0:3976::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/gru05.jsonnet
+++ b/sites/gru05.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'gru05',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.151.220.77/32',
+        },
+        ipv6+: {
+          address: '2600:1900:40f0:7602::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'SA',
+    country_code: 'BR',
+    metro: 'gru',
+    city: 'Sao Paulo',
+    state: '',
+    latitude: -23.4305,
+    longitude: -46.473,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/hel01.jsonnet
+++ b/sites/hel01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'hel01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '35.228.103.192/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4150:c32e::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'FI',
+    metro: 'hel',
+    city: 'Helsinki',
+    state: '',
+    latitude: 60.3172,
+    longitude: 24.9633,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/hkg04.jsonnet
+++ b/sites/hkg04.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'hkg04',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.150.68.57/32',
+        },
+        ipv6+: {
+          address: '2600:1900:41a0:f002::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'HK',
+    metro: 'hkg',
+    city: 'Hong Kong',
+    state: '',
+    latitude: 22.3089,
+    longitude: 113.9144,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/hnd06.jsonnet
+++ b/sites/hnd06.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'hnd06',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.146.53.42/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4050:46::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'JP',
+    metro: 'hnd',
+    city: 'Tokyo',
+    state: '',
+    latitude: 35.5522,
+    longitude: 139.78,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/iad07.jsonnet
+++ b/sites/iad07.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '34.85.166.60/32',
         },
+        ipv6+: {
+          address: '2600:1900:4090:5709::/128',
+        },
       },
       project: 'mlab-oti',
     },

--- a/sites/icn01.jsonnet
+++ b/sites/icn01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'icn01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.64.61.249/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8180:af78::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'KR',
+    metro: 'icn',
+    city: 'Seoul',
+    state: '',
+    latitude: 37.4633,
+    longitude: 126.44,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/kix01.jsonnet
+++ b/sites/kix01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'kix01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.97.176.53/32',
+        },
+        ipv6+: {
+          address: '2600:1900:41d0:8f23::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'JP',
+    metro: 'kix',
+    city: 'Osaka',
+    state: '',
+    latitude: 34.4342,
+    longitude: 135.2328,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/las01.jsonnet
+++ b/sites/las01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'las01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.125.158.248/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4180:ed51::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'las',
+    city: 'Las Vegas',
+    state: 'NV',
+    latitude: 36.08,
+    longitude: -115.1522,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/mad07.jsonnet
+++ b/sites/mad07.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'mad07',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.175.235.120/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8100:dbfc::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'ES',
+    metro: 'mad',
+    city: 'Madrid',
+    state: '',
+    latitude: 40.4667,
+    longitude: -3.5667,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/mel01.jsonnet
+++ b/sites/mel01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'mel01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.129.235.132/32',
+        },
+        ipv6+: {
+          address: '2600:1900:41c0:feec::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'OC',
+    country_code: 'AU',
+    metro: 'mel',
+    city: 'Melbourne',
+    state: '',
+    latitude: -37.6733,
+    longitude: 144.8433,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/mil08.jsonnet
+++ b/sites/mil08.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'mil08',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.154.171.24/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8110:97b::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'IT',
+    metro: 'mil',
+    city: 'Milan',
+    state: '',
+    latitude: 45.464,
+    longitude: 9.1916,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '35.226.8.239/32',
         },
+        ipv6+: {
+          address: '2600:1900:4000:2264::/128',
+        },
       },
       project: 'mlab-oti',
     },

--- a/sites/par08.jsonnet
+++ b/sites/par08.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'par08',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.155.83.192/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8120:8014::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'FR',
+    metro: 'par',
+    city: 'Paris',
+    state: '',
+    latitude: 48.8584,
+    longitude: 2.349,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/scl05.jsonnet
+++ b/sites/scl05.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'scl05',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.176.106.68/32',
+        },
+        ipv6+: {
+          address: '2600:1901:4010:c39::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'SA',
+    country_code: 'CL',
+    metro: 'scl',
+    city: 'Santiago',
+    state: '',
+    latitude: -33.3928,
+    longitude: -70.7856,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/sea09.jsonnet
+++ b/sites/sea09.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '34.105.122.11/32',
         },
+        ipv6+: {
+          address: '2600:1900:4040:ed0d::/128',
+        },
       },  
       project: 'mlab-oti',
     },

--- a/sites/sin02.jsonnet
+++ b/sites/sin02.jsonnet
@@ -11,6 +11,9 @@ sitesDefault {
         ipv4+: {
           address: '34.124.169.175/32',
         },
+        ipv6+: {
+          address: '2600:1900:4080:5afb::/128',
+        },
       },  
       project: 'mlab-oti',
     },

--- a/sites/slc01.jsonnet
+++ b/sites/slc01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'slc01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.106.93.110/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4170:2ab0::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'slc',
+    city: 'Salt Lake City',
+    state: 'UT',
+    latitude: 40.7883,
+    longitude: -111.9778,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/syd07.jsonnet
+++ b/sites/syd07.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'syd07',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '35.201.6.115/32',
+        },
+        ipv6+: {
+          address: '2600:1900:40b0:16a4::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'OC',
+    country_code: 'AU',
+    metro: 'syd',
+    city: 'Sydney',
+    state: '',
+    latitude: -33.9461,
+    longitude: 151.177,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/waw01.jsonnet
+++ b/sites/waw01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'waw01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.118.70.240/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4140:a999::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'PL',
+    metro: 'waw',
+    city: 'Warsaw',
+    state: '',
+    latitude: 52.1658,
+    longitude: 20.9672,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/yul07.jsonnet
+++ b/sites/yul07.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'yul07',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.95.21.36/32',
+        },
+        ipv6+: {
+          address: '2600:1900:40e0:7615::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'CA',
+    metro: 'yul',
+    city: 'Montreal',
+    state: '',
+    latitude: 45.4576,
+    longitude: -73.7497,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/yyz07.jsonnet
+++ b/sites/yyz07.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'yyz07',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.130.103.14/32',
+        },
+        ipv6+: {
+          address: '2600:1900:41e0:35a9::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'CA',
+    metro: 'yyz',
+    city: 'Toronto',
+    state: '',
+    latitude: 43.6767,
+    longitude: -79.6306,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}

--- a/sites/zrh01.jsonnet
+++ b/sites/zrh01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'zrh01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.65.61.93/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4160:623a::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'CH',
+    metro: 'zrh',
+    city: 'Zurich',
+    state: '',
+    latitude: 47.4647,
+    longitude: 8.5492,
+  },
+  lifecycle+: {
+    created: '2022-09-08',
+  },
+}


### PR DESCRIPTION
The fast canary phase of "cloud" sites is now done, and we are moving into the phase of deploying virtual sites (with a single mlab1 node) into all of the remaining GCP regions that the fast canary didn't already cover. The fast canary phase deployed virtual sites to 10 GCP regions, this PR adds virtual sites to the remaining 24 GCP regions.

Additionally, this PR includes updates to 7 or 8 of the original fast canary virtual sites, adding IPv6 addresses to them. At the time the original fast canary virtual sites were created (~6m ago), GCP only supported IPv6 VMs in 4 regions. Since then, IPv6 is now supported in all regions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/245)
<!-- Reviewable:end -->
