### PR TITLE
Tests virtual sites with multiple VMs

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -16,6 +16,20 @@ sitesDefault {
       },
       project: 'mlab-sandbox',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n1-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.74.30.247/32',
+        },
+        ipv6: {
+          address: '2600:1900:4020:31cd:0:2::/128',
+        },
+      },
+      project: 'mlab-sandbox',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/iad08.jsonnet
+++ b/sites/iad08.jsonnet
@@ -6,6 +6,20 @@ sitesDefault {
     provider: 'gcp',
   },
   machines: {
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n1-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.145.210.246/32',
+        },
+        ipv6: {
+          address: '2600:1900:4090:6589::/128',
+        },
+      },
+      project: 'mlab-staging',
+    },
     mlab4: {
       disk: 'pd-standard',
       iface: 'ens4',


### PR DESCRIPTION
This PR adds a second VM (mlab2) to testing site chs0t and a second VM (mlab3) to virtual staging site iad08. Interestingly, we've never had a non-mlab4 machine in the staging cluster, but we do now.

This PR tests having multiple VMs at a virtual site in preparation for adding two new VMs to the virtual site bom03. The goal is to test how virtual sites compare to physical sites in a metro when they have the same number of nodes and the same probability of being selected.

```
$ kubectl --context mlab-sandbox get nodes | grep chs0t
mlab1-chs0t.mlab-sandbox.measurement-lab.org   Ready    <none>                 226d   v1.22.15
mlab2-chs0t.mlab-sandbox.measurement-lab.org   Ready    <none>                 23h    v1.22.15

$ kubectl --context mlab-staging get nodes | grep iad08
mlab3-iad08.mlab-staging.measurement-lab.org   Ready      <none>                 4h25m   v1.22.15
mlab4-iad08.mlab-staging.measurement-lab.org   Ready      <none>                 167d    v1.21.14
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/247)
<!-- Reviewable:end -->
