### PR TITLE
Adds virtual site pdx01, and virtual node mlab1-oma01

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -44,6 +44,7 @@ local retiredSites = {
   sea01: import 'sites/sea01.jsonnet',
   sea05: import 'sites/sea05.jsonnet',
   sea06: import 'sites/sea06.jsonnet',
+  sea09: import 'sites/sea09.jsonnet',
   sjc01: import 'sites/sjc01.jsonnet',
   syd01: import 'sites/syd01.jsonnet',
   syd02: import 'sites/syd02.jsonnet',

--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -39,6 +39,7 @@ local retiredSites = {
   nuq01: import 'sites/nuq01.jsonnet',
   nuq05: import 'sites/nuq05.jsonnet',
   ord01: import 'sites/ord01.jsonnet',
+  ord07: import 'sites/ord07.jsonnet',
   par01: import 'sites/par01.jsonnet',
   prg01: import 'sites/prg01.jsonnet',
   sea01: import 'sites/sea01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -175,6 +175,7 @@ local sites = {
   par06: import 'sites/par06.jsonnet',
   par07: import 'sites/par07.jsonnet',
   par08: import 'sites/par08.jsonnet',
+  pdx01: import 'sites/pdx01.jsonnet',
   per01: import 'sites/per01.jsonnet',
   per02: import 'sites/per02.jsonnet',
   prg02: import 'sites/prg02.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -193,7 +193,6 @@ local sites = {
   sea04: import 'sites/sea04.jsonnet',
   sea07: import 'sites/sea07.jsonnet',
   sea08: import 'sites/sea08.jsonnet',
-  sea09: import 'sites/sea09.jsonnet',
   sin01: import 'sites/sin01.jsonnet',
   sin02: import 'sites/sin02.jsonnet',
   slc01: import 'sites/slc01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -167,7 +167,6 @@ local sites = {
   ord04: import 'sites/ord04.jsonnet',
   ord05: import 'sites/ord05.jsonnet',
   ord06: import 'sites/ord06.jsonnet',
-  ord07: import 'sites/ord07.jsonnet',
   par02: import 'sites/par02.jsonnet',
   par03: import 'sites/par03.jsonnet',
   par04: import 'sites/par04.jsonnet',

--- a/sites/_default_virtual.jsonnet
+++ b/sites/_default_virtual.jsonnet
@@ -13,7 +13,7 @@ site {
     mlab1: {
       disk: 'pd-ssd',
       iface: 'ens4',
-      model: 'n1-highcpu-4',
+      model: 'n2-highcpu-4',
       network: {
         ipv4: {
           address: error 'Must override IPv4 address',

--- a/sites/oma01.jsonnet
+++ b/sites/oma01.jsonnet
@@ -6,6 +6,17 @@ sitesDefault {
     provider: 'gcp',
   },
   machines: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.132.178.43/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4000:2264:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
     mlab4: {
       disk: 'pd-standard',
       iface: 'ens4',

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -34,5 +34,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2022-03-02',
+    retired: '2022-10-21',
   },
 }

--- a/sites/pdx01.jsonnet
+++ b/sites/pdx01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'pdx01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.168.208.61/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4040:ed0d:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'pdx',
+    city: 'Portland',
+    state: 'OR',
+    latitude: 45.5886,
+    longitude: -122.5975,
+  },
+  lifecycle+: {
+    created: '2022-10-21',
+  },
+}

--- a/sites/sea09.jsonnet
+++ b/sites/sea09.jsonnet
@@ -34,5 +34,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2022-03-02',
+    retired: '2022-10-21',
   },
 }


### PR DESCRIPTION
This PR resolves the issue a couple of virtual sites not being properly geolocated with respect to the GCP region they were deployed in. The improper geolocation was intentional, but was part of the early "fast canary" for virtual sites. Now that we have passed that phase, we want sites more accurately geolocated.

pdx01 is replacing sea09 for GCP region us-west1, which is actually in Oregon and closer to Portland than Seattle. sea09 is being retired.

mlab1-oma01 is replacing ord07 for GCP region us-central1, being added to existing virtual site oma01 (mlab4-oma01 in staging already existed). ord07 is being retired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/249)
<!-- Reviewable:end -->
