### PR TITLE
Adds new GCP virtual site TLV01

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -204,6 +204,7 @@ local sites = {
   syd06: import 'sites/syd06.jsonnet',
   syd07: import 'sites/syd07.jsonnet',
   tgd01: import 'sites/tgd01.jsonnet',
+  tlv01: import 'sites/tlv01.jsonnet',
   tnr01: import 'sites/tnr01.jsonnet',
   tpe01: import 'sites/tpe01.jsonnet',
   tpe02: import 'sites/tpe02.jsonnet',

--- a/sites/tlv01.jsonnet
+++ b/sites/tlv01.jsonnet
@@ -1,0 +1,38 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'tlv01',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.165.203.195/32',
+        },
+        ipv6+: {
+          address: '2600:1901:8160:9036::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'IL',
+    metro: 'tlv',
+    city: 'Tel Aviv',
+    state: '',
+    latitude: 32.0094,
+    longitude: 34.8828,
+  },
+  lifecycle+: {
+    created: '2022-11-02',
+  },
+}


### PR DESCRIPTION
In the past week or so Google opened a new GCP region,  `me-west1`, in Tel Aviv, Israel. This PR adds a virtual site, TLV01, in this new region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/252)
<!-- Reviewable:end -->
