### PR TITLE
Retires 1g CIRA-managed HE site YQM01

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -52,6 +52,7 @@ local retiredSites = {
   trn01: import 'sites/trn01.jsonnet',
   vie01: import 'sites/vie01.jsonnet',
   wlg01: import 'sites/wlg01.jsonnet',
+  yqm01: import 'sites/yqm01.jsonnet',
   yul01: import 'sites/yul01.jsonnet',
   yvr01: import 'sites/yvr01.jsonnet',
   ywg01: import 'sites/ywg01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -212,7 +212,6 @@ local sites = {
   tun01: import 'sites/tun01.jsonnet',
   waw01: import 'sites/waw01.jsonnet',
   wlg02: import 'sites/wlg02.jsonnet',
-  yqm01: import 'sites/yqm01.jsonnet',
   yqm02: import 'sites/yqm02.jsonnet',
   yul02: import 'sites/yul02.jsonnet',
   yul03: import 'sites/yul03.jsonnet',

--- a/sites/yqm01.jsonnet
+++ b/sites/yqm01.jsonnet
@@ -47,5 +47,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2022-11-29',
   },
 }


### PR DESCRIPTION
All of the other 1g CIRA-managed HE sites went down a month or two ago when the CIRA contracts expired. For some reason this site never went down, but according to CIRA the contract is expired. This seems like a possible oversight within HE. In any case there is new Google-managed 10g HE site on the way, which will be replacing this one soon. This commit is retiring the legacy 1g site before HE abruptly disconnects it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/254)
<!-- Reviewable:end -->
