### PR TITLE
Adds a 3rd VM (mlab3) to virtual site bom03

### DIFF
--- a/sites/bom03.jsonnet
+++ b/sites/bom03.jsonnet
@@ -31,6 +31,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.100.186.169/32',
+        },
+        ipv6: {
+          address: '2600:1900:40a0:f2f2:0:2::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',


### PR DESCRIPTION
This is in anticipation of likely testing bom03 as a virtual-only metro.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/255)
<!-- Reviewable:end -->
