### PR TITLE
Updates IPv4 address for mlab1-chs0t

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -24,7 +24,9 @@ sitesDefault {
         ipv4: {
           address: '34.74.30.247/32',
         },
-        ipv6: null,
+        ipv6: {
+          address: null,
+        },
       },
       project: 'mlab-sandbox',
     },

--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -11,7 +11,7 @@ sitesDefault {
       disk: 'pd-standard',
       network+: {
         ipv4+: {
-          address: '34.73.52.238/32',
+          address: '34.139.153.144/32',
         },
       },
       project: 'mlab-sandbox',
@@ -19,14 +19,12 @@ sitesDefault {
     mlab2: {
       disk: 'pd-ssd',
       iface: 'ens4',
-      model: 'n1-highcpu-4',
+      model: 'n2-highcpu-4',
       network: {
         ipv4: {
           address: '34.74.30.247/32',
         },
-        ipv6: {
-          address: '2600:1900:4020:31cd:0:2::/128',
-        },
+        ipv6: null,
       },
       project: 'mlab-sandbox',
     },

--- a/sites/lax0t.jsonnet
+++ b/sites/lax0t.jsonnet
@@ -9,7 +9,6 @@ sitesDefault {
   machines+: {
     mlab1+: {
       disk: 'pd-standard',
-      model: 'n1-highcpu-4',
       network+: {
         ipv4+: {
           address: '34.94.47.22/32',

--- a/sites/lax0t.jsonnet
+++ b/sites/lax0t.jsonnet
@@ -9,12 +9,10 @@ sitesDefault {
   machines+: {
     mlab1+: {
       disk: 'pd-standard',
+      model: 'n1-highcpu-4',
       network+: {
         ipv4+: {
           address: '34.94.47.22/32',
-        },
-        ipv6+: {
-          address: '2600:1900:4120:8f83:0:5::/128',
         },
       },  
       project: 'mlab-sandbox',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -9,7 +9,6 @@ sitesDefault {
   machines+: {
     mlab1+: {
       disk: 'pd-standard',
-      model: 'n1-highcpu-4',
       network+: {
         ipv4+: {
           address: '35.247.89.22/32',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -9,6 +9,7 @@ sitesDefault {
   machines+: {
     mlab1+: {
       disk: 'pd-standard',
+      model: 'n1-highcpu-4',
       network+: {
         ipv4+: {
           address: '35.247.89.22/32',


### PR DESCRIPTION
Also removes IPv6 addresses from all machines that had them. Static IPv6 configs for virtual machines are not workable until GCP supports creating static IPv6 addressing.

Also updates the machine type for a couple of VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/258)
<!-- Reviewable:end -->
