### PR TITLE
Adds mlab2 and 3 to virtual sites gru05 and hnd06

### DIFF
--- a/sites/gru05.jsonnet
+++ b/sites/gru05.jsonnet
@@ -17,6 +17,34 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.95.184.44/32',
+        },
+        ipv6: {
+          address: '2600:1900:40f0:7602:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.151.210.91/32',
+        },
+        ipv6: {
+          address: '2600:1900:40f0:7602:0:2::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/hnd06.jsonnet
+++ b/sites/hnd06.jsonnet
@@ -17,6 +17,34 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.84.128.7/32',
+        },
+        ipv6: {
+          address: '2600:1900:4050:46:0:3::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.84.73.144/32',
+        },
+        ipv6: {
+          address: '2600:1900:4050:46:0:4::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',


### PR DESCRIPTION
We are going to expand the experiment of migrating entire metros from physical infrastructure to virtual to Sao Paulo (gru) and Tokyo (hnd). This PR adds two additional VMs to the existing virtual sites in these metros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/259)
<!-- Reviewable:end -->
