### PR TITLE
Add mlab2 to waw01 and fra07

### DIFF
--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '35.198.143.217/32',
+        },
+        ipv6: {
+          address: '2600:1900:40d0:3976:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/waw01.jsonnet
+++ b/sites/waw01.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.118.35.144/32',
+        },
+        ipv6: {
+          address: '2600:1900:4140:a999:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',


### PR DESCRIPTION
This change adds one additional cloud VM to two cloud sites in preparation for directing some traffic from PRG to regional cloud sites.

Part of:
* https://github.com/m-lab/ops-tracker/issues/1720

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/261)
<!-- Reviewable:end -->
