### PR TITLE
Add probability to registration format

### DIFF
--- a/formats/v2/sites/registration.json.jsonnet
+++ b/formats/v2/sites/registration.json.jsonnet
@@ -12,6 +12,7 @@ local sites = import 'sites.jsonnet';
     Longitude: loc.longitude,
     Machine: machine,
     Type: site.annotations.type,
+    Probability: site.annotations.probability,
     Metro: loc.metro,
     Project: m.project,
     Site: site.name,

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -5,7 +5,7 @@ site {
   annotations: {
     provider: 'mlab',
     type: 'physical',
-    probability: 1,
+    probability: 1.0,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -5,6 +5,7 @@ site {
   annotations: {
     provider: 'mlab',
     type: 'physical',
+    probability: 1,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/_default_virtual.jsonnet
+++ b/sites/_default_virtual.jsonnet
@@ -5,6 +5,7 @@ site {
   annotations: {
     provider: 'mlab',
     type: 'virtual',
+    probability: 1,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/_default_virtual.jsonnet
+++ b/sites/_default_virtual.jsonnet
@@ -5,7 +5,7 @@ site {
   annotations: {
     provider: 'mlab',
     type: 'virtual',
-    probability: 1,
+    probability: 0.2,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'ams10',
   annotations+: {
     provider: 'gcp',
+    probability: 0,2,
   },
   machines+: {
     mlab1+: {

--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -4,7 +4,7 @@ sitesDefault {
   name: 'ams10',
   annotations+: {
     provider: 'gcp',
-    probability: 0,2,
+    probability: 0.2,
   },
   machines+: {
     mlab1+: {

--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'ams10',
   annotations+: {
     provider: 'gcp',
-    probability: 0.2,
   },
   machines+: {
     mlab1+: {

--- a/sites/bom01.jsonnet
+++ b/sites/bom01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'bom01',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/bom02.jsonnet
+++ b/sites/bom02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'bom02',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'fra07',
   annotations+: {
     provider: 'gcp',
+    probability: 1.0,
   },
   machines+: {
     mlab1+: {

--- a/sites/gru01.jsonnet
+++ b/sites/gru01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'gru01',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/gru02.jsonnet
+++ b/sites/gru02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'gru02',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/gru03.jsonnet
+++ b/sites/gru03.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'gru03',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/gru04.jsonnet
+++ b/sites/gru04.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'gru04',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/hnd02.jsonnet
+++ b/sites/hnd02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'hnd02',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/hnd03.jsonnet
+++ b/sites/hnd03.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'hnd03',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/hnd04.jsonnet
+++ b/sites/hnd04.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'hnd04',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/hnd05.jsonnet
+++ b/sites/hnd05.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'hnd05',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/lga1t.jsonnet
+++ b/sites/lga1t.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'lga1t',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/lis01.jsonnet
+++ b/sites/lis01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'lis01',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/lju01.jsonnet
+++ b/sites/lju01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'lju01',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/prg02.jsonnet
+++ b/sites/prg02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'prg02',
   annotations+: {
     type: 'physical',
+    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/prg03.jsonnet
+++ b/sites/prg03.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'prg03',
   annotations+: {
     type: 'physical',
+    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/prg04.jsonnet
+++ b/sites/prg04.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'prg04',
   annotations+: {
     type: 'physical',
+    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/prg05.jsonnet
+++ b/sites/prg05.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'prg05',
   annotations+: {
     type: 'physical',
+    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/prg06.jsonnet
+++ b/sites/prg06.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'prg06',
   annotations+: {
     type: 'physical',
+    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/tun01.jsonnet
+++ b/sites/tun01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'tun01',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/vie01.jsonnet
+++ b/sites/vie01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   lifecycle+: {
     created: '2012-05-10',

--- a/sites/waw01.jsonnet
+++ b/sites/waw01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'waw01',
   annotations+: {
     provider: 'gcp',
+    probability: 1.0,
   },
   machines+: {
     mlab1+: {

--- a/sites/yqm01.jsonnet
+++ b/sites/yqm01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'yqm01',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/yul02.jsonnet
+++ b/sites/yul02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'yul02',
   annotations+: {
     type: 'physical',
+    probability: 0.2,
   },
   machines+: {
     mlab1+: {

--- a/sites/yvr01.jsonnet
+++ b/sites/yvr01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'yvr01',
   annotations+: {
     type: 'physical',
+    probability: 0.1,
   },
   machines+: {
     mlab1+: {

--- a/sites/ywg01.jsonnet
+++ b/sites/ywg01.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'ywg01',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/ywg02.jsonnet
+++ b/sites/ywg02.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'ywg02',
   annotations+: {
     type: 'physical',
-    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/ywg02.jsonnet
+++ b/sites/ywg02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'ywg02',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/yyc02.jsonnet
+++ b/sites/yyc02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'yyc02',
   annotations+: {
     type: 'physical',
+    probability: 0.5,
   },
   machines+: {
     mlab1+: {

--- a/sites/yyz02.jsonnet
+++ b/sites/yyz02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'yyz02',
   annotations+: {
     type: 'physical',
+    probability: 0.2,
   },
   machines+: {
     mlab1+: {


### PR DESCRIPTION
Add probabilities to the registration format. Default values are 1.0 for physical sites and 0.2 for virtual ones. 

Source: https://github.com/m-lab/locate/blob/main/static/configs.go#L85.

Test: https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/registration.json.

Related to https://github.com/m-lab/locate/issues/92.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/263)
<!-- Reviewable:end -->
