### PR TITLE
Updates IPv4 info for virtual site chs0t

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -11,7 +11,7 @@ sitesDefault {
       disk: 'pd-standard',
       network+: {
         ipv4+: {
-          address: '34.139.153.144/32',
+          address: '34.138.51.232/32',
         },
       },
       project: 'mlab-sandbox',
@@ -22,10 +22,10 @@ sitesDefault {
       model: 'n2-highcpu-4',
       network: {
         ipv4: {
-          address: '34.74.30.247/32',
+          address: '35.185.69.66/32',
         },
         ipv6: {
-          address: null,
+          address: '2600:1900:4020:31cd:0:36::/128',
         },
       },
       project: 'mlab-sandbox',


### PR DESCRIPTION
The load balancer IP for mlab1-chs0t was incorrect, probably because of my Terraform testing and redeployment.

chs0t actually didn't have an mlab2 machine, though our siteinfo configs said it did, so I just updated the existing machine record with the IP address of the new mlab2 machine. This mlab2 machine is not part of a MIG, but is out older, standard type of VM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/265)
<!-- Reviewable:end -->
