### PR TITLE
Adds 3 new VMs with network-tier of STANDARD

### DIFF
--- a/sites/chs01.jsonnet
+++ b/sites/chs01.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '35.211.73.225/32',
+        },
+        ipv6: {
+          address: '2600:1900:4020:5b68:0:2::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/iad07.jsonnet
+++ b/sites/iad07.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '35.212.126.50/32',
+        },
+        ipv6: {
+          address: '2600:1900:4090:5709:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/yul07.jsonnet
+++ b/sites/yul07.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '35.215.55.247/32',
+        },
+        ipv6: {
+          address: '2600:1900:40e0:7615:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',


### PR DESCRIPTION
This is a test to see whether in some cases standard networking actually performs better thatn premium network in GCP. These are all mlab2 machines at existing sites where the mlab1 VM is premium network tier. We will be able to compare results between the two VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/266)
<!-- Reviewable:end -->
