### PR TITLE
Fixes IP addresses for virtual machines

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -11,7 +11,7 @@ sitesDefault {
       disk: 'pd-standard',
       network+: {
         ipv4+: {
-          address: '34.138.51.232/32',
+          address: '34.148.229.79/32',
         },
       },
       project: 'mlab-sandbox',
@@ -25,7 +25,7 @@ sitesDefault {
           address: '34.23.227.171/32',
         },
         ipv6: {
-          address: '2600:1900:4020:31cd:0:5d::/128',
+          address: '2600:1900:4020:31cd:0:5f::/128',
         },
       },
       project: 'mlab-sandbox',

--- a/sites/iad08.jsonnet
+++ b/sites/iad08.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
           address: '34.145.210.246/32',
         },
         ipv6: {
-          address: '2600:1900:4090:6589::/128',
+          address: '2600:1900:4090:6589:0:1::/128',
         },
       },
       project: 'mlab-staging',
@@ -29,7 +29,7 @@ sitesDefault {
           address: '35.245.211.241/32',
         },
         ipv6: {
-          address: null,
+          address: '2600:1900:4090:6589:0:2::/128',
         },
       },
       project: 'mlab-staging',

--- a/sites/lax08.jsonnet
+++ b/sites/lax08.jsonnet
@@ -15,7 +15,7 @@ sitesDefault {
           address: '34.102.101.93/32',
         },
         ipv6: {
-          address: '2600:1900:4120:7571::/128',
+          address: '2600:1900:4120:7571:0:1::/128',
         },
       },
       project: 'mlab-staging',

--- a/sites/lax0t.jsonnet
+++ b/sites/lax0t.jsonnet
@@ -11,7 +11,7 @@ sitesDefault {
       disk: 'pd-standard',
       network+: {
         ipv4+: {
-          address: '34.94.92.192/32',
+          address: '34.94.127.235/32',
         },
       },  
       project: 'mlab-sandbox',

--- a/sites/oma01.jsonnet
+++ b/sites/oma01.jsonnet
@@ -26,7 +26,7 @@ sitesDefault {
           address: '104.197.205.150/32',
         },
         ipv6: {
-          address: '2600:1900:4000:bcb9::/128',
+          address: '2600:1900:4000:bcb9:0:5::/128',
         },
       },
       project: 'mlab-staging',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -11,7 +11,7 @@ sitesDefault {
       disk: 'pd-standard',
       network+: {
         ipv4+: {
-          address: '34.83.63.126/32',
+          address: '34.127.102.87/32',
         },
       },
       project: 'mlab-sandbox',


### PR DESCRIPTION
In sandbox, somehow the IPv4 addresses we had configured for the loadbalancer were all wrong, and (just coincidentally?) the wrong IP addresses happened to be assigned to VMs in the managed instance group such that things still worked, even though the loadbalancer was being bypassed. This seems like a huge coincidence, and may have been user error on my part at some point in the past.

Additionally, after I brought the staging VMs under Terraform control their ephemeral IPv6 addresses changed, and this commit updates them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/270)
<!-- Reviewable:end -->
