### PR TITLE
Retires Zayo site LAX05

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -28,6 +28,7 @@ local retiredSites = {
   iad01: import 'sites/iad01.jsonnet',
   iad05: import 'sites/iad05.jsonnet',
   lax01: import 'sites/lax01.jsonnet',
+  lax05: import 'sites/lax05.jsonnet',
   lba01: import 'sites/lba01.jsonnet',
   lca01: import 'sites/lca01.jsonnet',
   lga01: import 'sites/lga01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -92,7 +92,6 @@ local sites = {
   lax02: import 'sites/lax02.jsonnet',
   lax03: import 'sites/lax03.jsonnet',
   lax04: import 'sites/lax04.jsonnet',
-  lax05: import 'sites/lax05.jsonnet',
   lax06: import 'sites/lax06.jsonnet',
   lax07: import 'sites/lax07.jsonnet',
   lax08: import 'sites/lax08.jsonnet',

--- a/sites/lax05.jsonnet
+++ b/sites/lax05.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2023-06-23',
   },
 }


### PR DESCRIPTION
This is part of the retirement of roughly 1/3 of physical sites to reduce costs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/273)
<!-- Reviewable:end -->
