### PR TITLE
Retires ISC site nuq02

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -45,6 +45,7 @@ local retiredSites = {
   mil01: import 'sites/mil01.jsonnet',
   mpm01: import 'sites/mpm01.jsonnet',
   nuq01: import 'sites/nuq01.jsonnet',
+  nuq02: import 'sites/nuq02.jsonnet',
   nuq05: import 'sites/nuq05.jsonnet',
   ord01: import 'sites/ord01.jsonnet',
   ord07: import 'sites/ord07.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -148,7 +148,6 @@ local sites = {
   mrs04: import 'sites/mrs04.jsonnet',
   mty01: import 'sites/mty01.jsonnet',
   nbo01: import 'sites/nbo01.jsonnet',
-  nuq02: import 'sites/nuq02.jsonnet',
   nuq03: import 'sites/nuq03.jsonnet',
   nuq04: import 'sites/nuq04.jsonnet',
   nuq06: import 'sites/nuq06.jsonnet',

--- a/sites/nuq02.jsonnet
+++ b/sites/nuq02.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2023-06-29',
   },
 }


### PR DESCRIPTION
The rebooted ISC site will be a test case for a 1U, single server site: https://github.com/m-lab/ops-tracker/issues/1795

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/275)
<!-- Reviewable:end -->
