### PR TITLE
Updates IPv6 address for mlab4-oma01

### DIFF
--- a/sites/oma01.jsonnet
+++ b/sites/oma01.jsonnet
@@ -26,7 +26,7 @@ sitesDefault {
           address: '104.197.205.150/32',
         },
         ipv6: {
-          address: '2600:1900:4000:bcb9:0:5::/128',
+          address: '2600:1900:4000:bcb9:0:1c::/128',
         },
       },
       project: 'mlab-staging',


### PR DESCRIPTION
The static IPv6 address was named like the following (capitalization mine for emphasis). This is probably okay, except for the fact that we need to run a script that counts on a correct name:

mlab4-oma01-mlab-staging-meaSRUment-lab-org-v6

Deleting and recreating the static address with a correct name changed the address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/280)
<!-- Reviewable:end -->
