### PR TITLE
Increases probability to 1 for many cloud sites

### DIFF
--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'ams10',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/bru06.jsonnet
+++ b/sites/bru06.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'bru06',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/del03.jsonnet
+++ b/sites/del03.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'del03',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/hkg04.jsonnet
+++ b/sites/hkg04.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'hkg04',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/lhr09.jsonnet
+++ b/sites/lhr09.jsonnet
@@ -5,7 +5,6 @@ sitesDefault {
   annotations+: {
     type: 'virtual',
     provider: 'gcp',
-    probability: 0.3,
   },
   machines: {
     mlab1: {

--- a/sites/ord07.jsonnet
+++ b/sites/ord07.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'ord07',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/sin02.jsonnet
+++ b/sites/sin02.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'sin02',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/syd07.jsonnet
+++ b/sites/syd07.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'syd07',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/tpe02.jsonnet
+++ b/sites/tpe02.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'tpe02',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {


### PR DESCRIPTION
These sites are in metros that already have a physical presence, so it should be safe to upgrade them to full probability without risking overwhelming the VM(s).

https://github.com/m-lab/ops-tracker/issues/1796

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/284)
<!-- Reviewable:end -->
