### PR TITLE
Reduce LIS probability for MAD trial

### DIFF
--- a/sites/arn01.jsonnet
+++ b/sites/arn01.jsonnet
@@ -14,9 +14,7 @@ sitesDefault {
     country_code: 'SE',
     latitude: 59.6519,
     longitude: 17.9186,
-    metro: {
-      metro: 'arn',
-    },
+    metro: 'arn',
     state: '',
   },
   name: 'arn01',

--- a/sites/lis01.jsonnet
+++ b/sites/lis01.jsonnet
@@ -4,7 +4,7 @@ sitesDefault {
   name: 'lis01',
   annotations+: {
     type: 'physical',
-    probability: 0.5,
+    probability: 0.2,
   },
   machines+: {
     mlab1+: {

--- a/sites/lis02.jsonnet
+++ b/sites/lis02.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'lis02',
   annotations+: {
     type: 'physical',
+    probability: 0.4,
   },
   machines+: {
     mlab1+: {

--- a/sites/lis03.jsonnet
+++ b/sites/lis03.jsonnet
@@ -4,6 +4,7 @@ sitesDefault {
   name: 'lis03',
   annotations+: {
     type: 'physical',
+    probability: 0.4,
   },
   machines+: {
     mlab1+: {


### PR DESCRIPTION
This change adds reduced site probabilities to all sites in the LIS metro. This change will collect measurements for client regions by directing them to a regional cloud companion metro in nearby MAD.

This change also corrects a typo in the retired arn01.jsonnet.

FYI: @laiyi-ohlsen this change is expected to go live next week.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/285)
<!-- Reviewable:end -->
