### PR TITLE
Use default probability for icn, kix, and mel cloud sites

### DIFF
--- a/sites/icn01.jsonnet
+++ b/sites/icn01.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'icn01',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/kix01.jsonnet
+++ b/sites/kix01.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'kix01',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {

--- a/sites/mel01.jsonnet
+++ b/sites/mel01.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'mel01',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {


### PR DESCRIPTION
This change increases site probability for cloud sites icn, kix, and mel based on expected load.

Part of:
* https://github.com/m-lab/ops-tracker/issues/1796

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/286)
<!-- Reviewable:end -->
