### PR TITLE
Adds additional VMs in regions where IST will rollout

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -53,6 +53,7 @@ local retiredSites = {
   ord05: import 'sites/ord05.jsonnet',
   ord07: import 'sites/ord07.jsonnet',
   par01: import 'sites/par01.jsonnet',
+  par06: import 'sites/par06.jsonnet',
   par07: import 'sites/par07.jsonnet',
   prg01: import 'sites/prg01.jsonnet',
   sea01: import 'sites/sea01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -160,7 +160,6 @@ local sites = {
   par03: import 'sites/par03.jsonnet',
   par04: import 'sites/par04.jsonnet',
   par05: import 'sites/par05.jsonnet',
-  par06: import 'sites/par06.jsonnet',
   par08: import 'sites/par08.jsonnet',
   pdx01: import 'sites/pdx01.jsonnet',
   per01: import 'sites/per01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -195,6 +195,7 @@ local sites = {
   tpe01: import 'sites/tpe01.jsonnet',
   tpe02: import 'sites/tpe02.jsonnet',
   trn02: import 'sites/trn02.jsonnet',
+  trn03: import 'sites/trn03.jsonnet',
   tun01: import 'sites/tun01.jsonnet',
   waw01: import 'sites/waw01.jsonnet',
   wlg02: import 'sites/wlg02.jsonnet',

--- a/sites/cgk01.jsonnet
+++ b/sites/cgk01.jsonnet
@@ -4,7 +4,6 @@ sitesDefault {
   name: 'cgk01',
   annotations+: {
     provider: 'gcp',
-    probability: 0.3,
   },
   machines+: {
     mlab1+: {
@@ -14,6 +13,34 @@ sitesDefault {
         },
         ipv6+: {
           address: '2600:1901:8170:40d1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.101.73.243/32',
+        },
+        ipv6: {
+          address: '2600:1901:8170:40d1:0:4::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.101.74.219/32',
+        },
+        ipv6: {
+          address: '2600:1901:8170:40d1:0:6::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/hel01.jsonnet
+++ b/sites/hel01.jsonnet
@@ -17,6 +17,34 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '35.228.166.113/32',
+        },
+        ipv6: {
+          address: '2600:1900:4150:c32e:0:6::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.88.132.171/32',
+        },
+        ipv6: {
+          address: '2600:1900:4150:c32e:0:5::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/icn01.jsonnet
+++ b/sites/icn01.jsonnet
@@ -17,6 +17,34 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.64.166.41/32',
+        },
+        ipv6: {
+          address: '2600:1901:8180:af78:0:6::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.64.251.143/32',
+        },
+        ipv6: {
+          address: '2600:1901:8180:af78:0:5::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/par06.jsonnet
+++ b/sites/par06.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2020-08-20',
+    retired: '2023-07-31',
   },
 }

--- a/sites/tpe02.jsonnet
+++ b/sites/tpe02.jsonnet
@@ -17,6 +17,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.80.84.0/32',
+        },
+        ipv6: {
+          address: '2600:1900:4030:ddef:0:5::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/trn03.jsonnet
+++ b/sites/trn03.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'trn03',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '34.17.52.81/32',
+        },
+        ipv6+: {
+          address: '2600:1901:81b0:3a4:0:1::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'IT',
+    metro: 'trn',
+    city: 'Turin',
+    state: '',
+    latitude: 45.2008,
+    longitude: 7.6497,
+  },
+  lifecycle+: {
+    created: '2023-08-02',
+  },
+}
+

--- a/sites/waw01.jsonnet
+++ b/sites/waw01.jsonnet
@@ -31,6 +31,20 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.118.16.253/32',
+        },
+        ipv6: {
+          address: '2600:1900:4140:a999:0:7::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/zrh01.jsonnet
+++ b/sites/zrh01.jsonnet
@@ -17,6 +17,34 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab2: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.65.123.191/32',
+        },
+        ipv6: {
+          address: '2600:1900:4160:623a:0:6::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
+    mlab3: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.65.175.253/32',
+        },
+        ipv6: {
+          address: '2600:1900:4160:623a:0:4::/128',
+        },
+      },
+      project: 'mlab-oti',
+    },
   },
   transit+: {
     provider: 'Google LLC',


### PR DESCRIPTION
IST will be rolling out in a number of new countries. This PR adds 2 additional VMs to countries where there are no physical machines deployed, and 1 additional VM in locations where M-Lab already has physical servers.

Additionally:
* retires site PAR06 (part of reduction of physical fleet)
* Sets probability for CGK01 to 1.0, now that there are 3 VMs there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/289)
<!-- Reviewable:end -->
