### PR TITLE
Updates IPv6 addrs for mlab2/3-dfw09

### DIFF
--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -26,7 +26,7 @@ sitesDefault {
           address: '34.174.104.110/32',
         },
         ipv6: {
-          address: '2600:1901:8140:9cd3:0:3::/128',
+          address: '2600:1901:8140:9cd3:0:6::/128',
         },
       },
       project: 'mlab-oti',
@@ -40,7 +40,7 @@ sitesDefault {
           address: '34.174.134.185/32',
         },
         ipv6: {
-          address: '2600:1901:8140:9cd3:0:2::/128',
+          address: '2600:1901:8140:9cd3:0:8::/128',
         },
       },
       project: 'mlab-oti',


### PR DESCRIPTION
I suspect this got out of sync with GCP because I deployed these machines before I had implemented the local-exec TF provisioner to make sure that all ephemeral IPv6 addresses on machines get converted to static addresses and get assigned to the VM on update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/290)
<!-- Reviewable:end -->
