### PR TITLE
Add mlab4-dfw09 MIG IPv4 network configuration

### DIFF
--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -45,13 +45,16 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
-    mlab4+: {
+    mlab4: {
       disk: 'pd-ssd',
       iface: 'ens4',
       model: 'n2-highcpu-4',
       network: {
         ipv4: {
           address: '34.174.31.191/32',
+        },
+        ipv6: {
+          address: null,
         },
       },
       project: 'mlab-staging',

--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -45,6 +45,17 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
+    mlab4: {
+      disk: 'pd-ssd',
+      iface: 'ens4',
+      model: 'n2-highcpu-4',
+      network: {
+        ipv4: {
+          address: '34.174.31.191/32',
+        },
+      },
+      project: 'mlab-staging',
+    },
   },
   transit+: {
     provider: 'Google LLC',

--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -45,7 +45,7 @@ sitesDefault {
       },
       project: 'mlab-oti',
     },
-    mlab4: {
+    mlab4+: {
       disk: 'pd-ssd',
       iface: 'ens4',
       model: 'n2-highcpu-4',


### PR DESCRIPTION
Currently, the ndt-virtual configuration for the [staging mlab4-dfw09](https://github.com/m-lab/terraform-support/pull/23) MIG is not yet registered in siteinfo. As a result, the pods can start completely without uuid-annotator or heartbeat registration.

This change adds the IPv4 network configuration for the MIG frontend loadbalancer address. These MIGs are not yet enabled with IPv6 addresses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/291)
<!-- Reviewable:end -->
