### PR TITLE
Reduce the probability of bom01 to 0.05

### DIFF
--- a/sites/bom01.jsonnet
+++ b/sites/bom01.jsonnet
@@ -4,7 +4,7 @@ sitesDefault {
   name: 'bom01',
   annotations+: {
     type: 'physical',
-    probability: 0.1,
+    probability: 0.05,
   },
   machines+: {
     mlab1+: {


### PR DESCRIPTION
There has been a spike in traffic to bom01, which is a 1g site. 

![Screenshot 2023-08-22 5 18 24 PM](https://github.com/m-lab/siteinfo/assets/21001496/ae620d46-d33b-44e7-af5e-3d72138eadc1)

This PR reduces the site's probability from 0.1 to 0.05.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/293)
<!-- Reviewable:end -->
