### PR TITLE
Adds IPv6 to sandbox MIGs + updates mlab3-dfw09 IPv4

### DIFF
--- a/sites/chs0t.jsonnet
+++ b/sites/chs0t.jsonnet
@@ -8,10 +8,12 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
-      disk: 'pd-standard',
       network+: {
         ipv4+: {
           address: '34.148.229.79/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4020:31cd:8000::/128',
         },
       },
       project: 'mlab-sandbox',

--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -37,10 +37,10 @@ sitesDefault {
       model: 'n2-highcpu-4',
       network: {
         ipv4: {
-          address: '34.174.134.185/32',
+          address: '34.174.143.111/32',
         },
         ipv6: {
-          address: '2600:1901:8140:9cd3:0:8::/128',
+          address: null
         },
       },
       project: 'mlab-oti',

--- a/sites/lax0t.jsonnet
+++ b/sites/lax0t.jsonnet
@@ -8,10 +8,12 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
-      disk: 'pd-standard',
       network+: {
         ipv4+: {
           address: '34.94.127.235/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4120:8f83:8000:1::/128',
         },
       },  
       project: 'mlab-sandbox',

--- a/sites/pdx0t.jsonnet
+++ b/sites/pdx0t.jsonnet
@@ -8,10 +8,12 @@ sitesDefault {
   },
   machines+: {
     mlab1+: {
-      disk: 'pd-standard',
       network+: {
         ipv4+: {
           address: '34.127.102.87/32',
+        },
+        ipv6+: {
+          address: '2600:1900:4040:85ea:8000::/128',
         },
       },
       project: 'mlab-sandbox',


### PR DESCRIPTION
The Google Terraform provider now supports creating static IPv6 addresses for VMs and load balancers. This PR adds IPv6 addresses to the MIG load balancers in sandbox.

This PR also updates the IPv4 address of mlab3-dfw09, which was previously a standalone VM, but which is now a MIG. It does not yet have an IPv6 address because the changes to terraform-support enabling this are still in [a PR which is approved but which  I have not yet merged](https://github.com/m-lab/terraform-support/pull/41).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/296)
<!-- Reviewable:end -->
