### PR TITLE
Fixes the IPv6 address for mlab3-dfw09

### DIFF
--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -40,7 +40,7 @@ sitesDefault {
           address: '34.174.109.248/32',
         },
         ipv6: {
-          address: '2600:1901:8140:9cd3:0:18::/128',
+          address: '2600:1901:8140:9cd3:0:8::/128',
         },
       },
       project: 'mlab-oti',


### PR DESCRIPTION
In the previous PR, I had mistakenly entered an ephemeral IPv6 address. This sets it back to what it should be.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/299)
<!-- Reviewable:end -->
