### PR TITLE
Adds new "select" test site nuq0t

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -193,6 +193,7 @@ local sites = {
   lax0t: import 'sites/lax0t.jsonnet',
   lga0t: import 'sites/lga0t.jsonnet',
   lga1t: import 'sites/lga1t.jsonnet',
+  nuq0t: import 'sites/nuq0t.jsonnet',
   pdx0t: import 'sites/pdx0t.jsonnet',
 };
 [

--- a/sites/nuq0t.jsonnet
+++ b/sites/nuq0t.jsonnet
@@ -1,0 +1,42 @@
+local sitesDefault = import 'sites/_default.jsonnet';
+
+sitesDefault {
+  name: 'nuq0t',
+  annotations+: {
+    type: 'physical',
+  },
+  machines: {
+    mlab1: {
+      disk: 'sda',
+      iface: 'eth0',
+      model: 'r630',
+      project: 'mlab-sandbox',
+    },
+  },
+  network+: {
+    ipv4+: {
+      prefix: '192.158.252.176/28',
+    },
+    ipv6+: {
+      prefix: null,
+    },
+  },
+  transit+: {
+    provider: 'Internet Systems Consortium, Inc.',
+    uplink: '10g',
+    asn: 'AS1280',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'nuq',
+    city: 'San Francisco Bay Area',
+    state: 'CA',
+    latitude: 37.3833,
+    longitude: -122.0667,
+  },
+  lifecycle+: {
+    created: '2023-11-29',
+  },
+}
+


### PR DESCRIPTION
The ISC used to host a full M-Lab site, but could no longer do so. Instead they said they could host 1U with a /28. The old ISC site nuq02 was retired some time ago. This is completely a test/sandbox site for now. Rather than the typical machines+:{} definition, this new site uses a static machines definition with only a single mlab1 machine, as well as a /28 IPv4 prefix which will surely have unknown behavior and/or breakage. This is just a first start for testing in sandbox.

This was the result of the sandbox build, which seems okay so far:

```
$ host mlab1-nuq0t.mlab-sandbox.measurement-lab.org
mlab1-nuq0t.mlab-sandbox.measurement-lab.org has address 192.158.252.185

$ host mlab1d-nuq0t.mlab-sandbox.measurement-lab.org
mlab1d-nuq0t.mlab-sandbox.measurement-lab.org has address 192.158.252.180

$ host mlab2-nuq0t.mlab-sandbox.measurement-lab.org
Host mlab2-nuq0t.mlab-sandbox.measurement-lab.org not found: 3(NXDOMAIN)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/308)
<!-- Reviewable:end -->
