### PR TITLE
Retires virtual sites DFW10 and DFW11

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -28,6 +28,8 @@ local retiredSites = {
   dfw05: import 'sites/dfw05.jsonnet',
   dfw06: import 'sites/dfw06.jsonnet',
   dfw07: import 'sites/dfw07.jsonnet',
+  dfw10: import 'sites/dfw10.jsonnet',
+  dfw11: import 'sites/dfw11.jsonnet',
   fra01: import 'sites/fra01.jsonnet',
   fra02: import 'sites/fra02.jsonnet',
   fra05: import 'sites/fra05.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -44,8 +44,6 @@ local sites = {
   dfw03: import 'sites/dfw03.jsonnet',
   dfw08: import 'sites/dfw08.jsonnet',
   dfw09: import 'sites/dfw09.jsonnet',
-  dfw10: import 'sites/dfw10.jsonnet',
-  dfw11: import 'sites/dfw11.jsonnet',
   doh01: import 'sites/doh01.jsonnet',
   dub01: import 'sites/dub01.jsonnet',
   eze01: import 'sites/eze01.jsonnet',

--- a/sites/dfw10.jsonnet
+++ b/sites/dfw10.jsonnet
@@ -62,5 +62,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2023-11-13',
+    retired: '2023-12-13',
   },
 }

--- a/sites/dfw11.jsonnet
+++ b/sites/dfw11.jsonnet
@@ -62,5 +62,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2023-11-28',
+    retired: '2023-12-13',
   },
 }


### PR DESCRIPTION
Now that the periodic client causing all the problems in DFW is being blocked and the switch discard issues have gone away, we no longer need this extra virtual capacity in DFW.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/310)
<!-- Reviewable:end -->
