### PR TITLE
Retires sites GIG03 and GIG04

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -38,6 +38,8 @@ local retiredSites = {
   fra05: import 'sites/fra05.jsonnet',
   gig01: import 'sites/gig01.jsonnet',
   gig02: import 'sites/gig02.jsonnet',
+  gig03: import 'sites/gig03.jsonnet',
+  gig04: import 'sites/gig04.jsonnet',
   gru01: import 'sites/gru01.jsonnet',
   gru04: import 'sites/gru04.jsonnet',
   ham01: import 'sites/ham01.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -52,8 +52,6 @@ local sites = {
   fra04: import 'sites/fra04.jsonnet',
   fra06: import 'sites/fra06.jsonnet',
   fra07: import 'sites/fra07.jsonnet',
-  gig03: import 'sites/gig03.jsonnet',
-  gig04: import 'sites/gig04.jsonnet',
   gru02: import 'sites/gru02.jsonnet',
   gru03: import 'sites/gru03.jsonnet',
   gru05: import 'sites/gru05.jsonnet',

--- a/sites/gig03.jsonnet
+++ b/sites/gig03.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2020-09-28',
+    retired: '2023-10-16',
   },
 }

--- a/sites/gig04.jsonnet
+++ b/sites/gig04.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2020-09-30',
+    retired: '2023-10-16',
   },
 }


### PR DESCRIPTION
I _thought_ I had retired these sites months ago:

https://github.com/m-lab/siteinfo/commit/f4de5e6ab927510f2a9970aaeb163205c9c35819

However, I just discovered that they were not actually retired. Most likely I pushed these changes to my sandbox branch with the intention of creating a PR, but probably pushed some other changes to my sandbox branch before I ever created the PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/314)
<!-- Reviewable:end -->
