### PR TITLE
Adds missing IPv6 address to mlab4-dfw09

### DIFF
--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -54,7 +54,7 @@ sitesDefault {
           address: '34.174.31.191/32',
         },
         ipv6: {
-          address: null,
+          address: '2600:1901:8140:31e:8000::/128',
         },
       },
       project: 'mlab-staging',


### PR DESCRIPTION
I was looking at logs for uuid-annotator in the ndt-virtual pod in mlab-staging on mlab4-dfw09 (a MIG) and was surprised to see error messages like `Can't annotate connection: Unknown direction` for the IPv6 address of the load balancer. I had expected the [recent update to uuid-annotator](https://github.com/m-lab/uuid-annotator/pull/63) to have resolved this, but then discovered that siteinfo didn't even have an IPv6 address configured for mlab4-dfw09. This PR should resolve that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/320)
<!-- Reviewable:end -->
