### PR TITLE
Adds back experiments ndt.iupui and mlab.neubot

### DIFF
--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -15,6 +15,11 @@ local default = {
     name: 'ndt',
   },
   default {
+    index: 2,
+    name: 'ndt.iupui',
+    cloud_enabled: true,
+  },
+  default {
     index: 3,
     name: 'revtr',
   },
@@ -45,6 +50,10 @@ local default = {
   default {
     index: 10,
     name: 'neubot',
+  },
+  default {
+    index: 10,
+    name: 'neubot.mlab',
   },
   default {
     index: 11,


### PR DESCRIPTION
Removing them breaks mlab-ns and the changes to accommodate this and make mlab-ns still work are too many, and involve even some bugs in GMX. It's too much work at the moment.

One practical effect this change has on supporting "minimal" sites with /28 and /29 IPv4 prefixes is that now /28 sites will only support up to index 10, and /29 sites will only support mask, ndt and ndt.iupui (without revtr). Both of these outcomes is probably just fine for v1 of minimal sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/321)
<!-- Reviewable:end -->
