### PR TITLE
Promotes ISC machinefrom sandbox to production

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -138,6 +138,7 @@ local retiredSites = {
 
   // Test sites.
   atl0t: import 'sites/atl0t.jsonnet',
+  nuq0t: import 'sites/nuq0t.jsonnet',
 };
 [
   local site = retiredSites[name];

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -120,6 +120,7 @@ local sites = {
   nuq03: import 'sites/nuq03.jsonnet',
   nuq04: import 'sites/nuq04.jsonnet',
   nuq06: import 'sites/nuq06.jsonnet',
+  nuq08: import 'sites/nuq08.jsonnet',
   oma01: import 'sites/oma01.jsonnet',
   ord02: import 'sites/ord02.jsonnet',
   ord03: import 'sites/ord03.jsonnet',
@@ -177,7 +178,6 @@ local sites = {
   lax0t: import 'sites/lax0t.jsonnet',
   lga0t: import 'sites/lga0t.jsonnet',
   lga1t: import 'sites/lga1t.jsonnet',
-  nuq0t: import 'sites/nuq0t.jsonnet',
   pdx0t: import 'sites/pdx0t.jsonnet',
 };
 [

--- a/sites/nuq08.jsonnet
+++ b/sites/nuq08.jsonnet
@@ -1,7 +1,7 @@
 local sitesDefault = import 'sites/_default.jsonnet';
 
 sitesDefault {
-  name: 'nuq0t',
+  name: 'nuq08',
   annotations+: {
     type: 'physical',
   },
@@ -10,7 +10,7 @@ sitesDefault {
       disk: 'sda',
       iface: 'eth0',
       model: 'r630',
-      project: 'mlab-sandbox',
+      project: 'mlab-oti',
     },
   },
   network+: {
@@ -37,7 +37,6 @@ sitesDefault {
     longitude: -122.0667,
   },
   lifecycle+: {
-    created: '2023-11-29',
-    retired: '2024-02-29',
+    created: '2024-02-29',
   },
 }


### PR DESCRIPTION
The test of the ISC "minimal" site with a single server and a /28 IPv4 prefix was successful in mlab-sandbox, and I believe we can now promote that machine to a new production site.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/322)
<!-- Reviewable:end -->
