### PR TITLE
Adds a new function MaxRate() to the site object

### DIFF
--- a/formats/v2/sites/max-rates.json.jsonnet
+++ b/formats/v2/sites/max-rates.json.jsonnet
@@ -1,22 +1,7 @@
 local sites = import 'sites.jsonnet';
 
-/*
-The max-rate for the -txcontroller.max-rate flag for ndt-server for 1Gbit/s
-sites is set to 150Mbit/s, which should mean that the combined throughput for a
-a site should not exceed 450Mbit/s, notwithstanding already running tests which
-may significantly exceed this number.
-*/
-local MaxRate1g = 150000000;
-
-/*
-The max-rate for the -txcontroller.max-rate flag for ndt-server for 10Gbit/s
-sites is set to 2.5Gbit/s, which should mean that the combined throughput for a
-a site should not exceed 7.5Gbit/s, notwithstanding already running tests which
-may significantly exceed this number.
-*/
-local MaxRate10g = 2500000000;
-
 {
-  [site.name]: if site.transit.uplink == '1g' then MaxRate1g else MaxRate10g
+  [site.name]: site.MaxRate()
   for site in sites
+  if site.annotations.type == 'physical'
 }

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -175,6 +175,28 @@ local version = std.extVar('version');
     else if subnet == 28 then 11
     else 3
   ),
+  // MaxRate returns the appropriate value for the -txcontroller.max-rate flag
+  // of ndt-server. It only applies to physical machines. The general rule is
+  // that the value for "minimal" (i.e., single server) sites should be 3x the
+  // rate for a "full" site.
+  MaxRate():: (
+    local subnet = $._net_subnet($.network.ipv4.prefix, 'v4');
+    local uplink = $.transit.uplink;
+    if uplink == '1g' then
+      if subnet == 26 then
+        // 150Mbits/s
+        150000000
+      else
+        // 450Mbits/s
+        450000000
+    else if
+      if subnet == 26 then
+        // 2.5Gbits/s
+        2500000000
+      else
+        // 7.5Gbits/s
+        7500000000
+  ),
 
   // Extract the last octet as an integer.
   _v4_net_offset(net):: std.parseInt(std.split(std.split(net, '/')[0], '.')[3]),

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -176,9 +176,11 @@ local version = std.extVar('version');
     else 3
   ),
   // MaxRate returns the appropriate value for the -txcontroller.max-rate flag
-  // of ndt-server. It only applies to physical machines. The general rule is
+  // of ndt-server. It only applies to physical machines. The _general_ rule is
   // that the value for "minimal" (i.e., single server) sites should be 3x the
-  // rate for a "full" site.
+  // rate for a "full" site. The one exception to this is for 1g sites, where a
+  // single fast client could exhaust the circuit, in which case we keep the
+  // value for minimal sites lower.
   MaxRate():: (
     local subnet = $._net_subnet($.network.ipv4.prefix, 'v4');
     local uplink = $.transit.uplink;
@@ -187,8 +189,8 @@ local version = std.extVar('version');
         // 150Mbits/s
         150000000
       else
-        // 450Mbits/s
-        450000000
+        // 300Mbits/s
+        300000000
     else
       if subnet == 26 then
         // 2.5Gbits/s

--- a/lib/site.jsonnet
+++ b/lib/site.jsonnet
@@ -189,7 +189,7 @@ local version = std.extVar('version');
       else
         // 450Mbits/s
         450000000
-    else if
+    else
       if subnet == 26 then
         // 2.5Gbits/s
         2500000000


### PR DESCRIPTION
Previously, we assumed that if a site was 1g the max-rate should be one static thing, and that if it was 10g it should be another static thing. The introduction of "minimal" sites that only have a single server changes this.

Minimal sites should have the max-rate set higher than "full" sites. The max-rate values only apply to physical sites, since the number is [currently static for all virtual sites](https://github.com/m-lab/k8s-support/blob/main/k8s/daemonsets/experiments/ndt-virtual.jsonnet#L67).

The results of the PR can be seen here:

https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/max-rates.json

Notably, site nuq0t has a max-rate of 7500000000, since nuq0t is the current ISC minimal pilot site.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/324)
<!-- Reviewable:end -->
