### PR TITLE
Add autojoin zone delegations

### DIFF
--- a/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
@@ -100,14 +100,14 @@ local primary_headers = |||
   ;
   ; Autojoin zone delegations.
   ;
-  sandbox          IN     NS      ns-cloud-a1.googledomains.com.
-                   IN     NS      ns-cloud-a2.googledomains.com.
-                   IN     NS      ns-cloud-a3.googledomains.com.
-                   IN     NS      ns-cloud-a4.googledomains.com.
-  staging          IN     NS      ns-cloud-d1.googledomains.com.
+  sandbox          IN     NS      ns-cloud-d1.googledomains.com.
                    IN     NS      ns-cloud-d2.googledomains.com.
                    IN     NS      ns-cloud-d3.googledomains.com.
                    IN     NS      ns-cloud-d4.googledomains.com.
+  staging          IN     NS      ns-cloud-b1.googledomains.com.
+                   IN     NS      ns-cloud-b2.googledomains.com.
+                   IN     NS      ns-cloud-b3.googledomains.com.
+                   IN     NS      ns-cloud-b4.googledomains.com.
 
 
   ;

--- a/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
@@ -100,10 +100,10 @@ local primary_headers = |||
   ;
   ; Autojoin zone delegations.
   ;
-  sandbox          IN     NS      ns-cloud-d1.googledomains.com.
-                   IN     NS      ns-cloud-d2.googledomains.com.
-                   IN     NS      ns-cloud-d3.googledomains.com.
-                   IN     NS      ns-cloud-d4.googledomains.com.
+  sandbox          IN     NS      ns-cloud-b1.googledomains.com.
+                   IN     NS      ns-cloud-b2.googledomains.com.
+                   IN     NS      ns-cloud-b3.googledomains.com.
+                   IN     NS      ns-cloud-b4.googledomains.com.
   staging          IN     NS      ns-cloud-b1.googledomains.com.
                    IN     NS      ns-cloud-b2.googledomains.com.
                    IN     NS      ns-cloud-b3.googledomains.com.

--- a/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
@@ -97,6 +97,18 @@ local primary_headers = |||
                    IN     NS      ns-cloud-d2.googledomains.com.
                    IN     NS      ns-cloud-d3.googledomains.com.
                    IN     NS      ns-cloud-d4.googledomains.com.
+  ;
+  ; Autojoin zone delegations.
+  ;
+  sandbox          IN     NS      ns-cloud-a1.googledomains.com.
+                   IN     NS      ns-cloud-a2.googledomains.com.
+                   IN     NS      ns-cloud-a3.googledomains.com.
+                   IN     NS      ns-cloud-a4.googledomains.com.
+  staging          IN     NS      ns-cloud-d1.googledomains.com.
+                   IN     NS      ns-cloud-d2.googledomains.com.
+                   IN     NS      ns-cloud-d3.googledomains.com.
+                   IN     NS      ns-cloud-d4.googledomains.com.
+
 
   ;
   ; Delegate acme subdomains to Cloud DNS servers.


### PR DESCRIPTION
This change adds new zone delegations for the sandbox and staging projects to the root measurement-lab-org zone.

These zones will be managed by the autojoin API with subzones for every registered organization. e.g. `mlab.sandbox.measurement-lab.org` or eventually `rnp.autojoin.measurement-lab.org`.

Before they can be effective, they must be deployed in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/325)
<!-- Reviewable:end -->
