### PR TITLE
Add autojoin zone delegations to both zone header files

### DIFF
--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -48,7 +48,17 @@ std.lines([
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.
                      IN     NS      ns-cloud-d4.googledomains.com.
-
+    ;
+    ; Autojoin zone delegations.
+    ;
+    sandbox          IN     NS      ns-cloud-b1.googledomains.com.
+                     IN     NS      ns-cloud-b2.googledomains.com.
+                     IN     NS      ns-cloud-b3.googledomains.com.
+                     IN     NS      ns-cloud-b4.googledomains.com.
+    staging          IN     NS      ns-cloud-b1.googledomains.com.
+                     IN     NS      ns-cloud-b2.googledomains.com.
+                     IN     NS      ns-cloud-b3.googledomains.com.
+                     IN     NS      ns-cloud-b4.googledomains.com.
   |||,
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]


### PR DESCRIPTION
This change completes the intention started in https://github.com/m-lab/siteinfo/pull/325 by adding the autojoin zone delegations to both measurement-lab.org zone files for the v1/v2 formats.

The v2 format now correctly includes these delegations: https://siteinfo.mlab-sandbox.measurementlab.net/v2/zones/measurement-lab.org.zone.diff

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/326)
<!-- Reviewable:end -->
