### PR TITLE
Adds placeholder sites for new production MIGs

### DIFF
--- a/sites/bom06.jsonnet
+++ b/sites/bom06.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'bom06',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'IN',
+    metro: 'bom',
+    city: 'Mumbai',
+    state: '',
+    latitude: 19.0886,
+    longitude: 72.8681,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/cgk02.jsonnet
+++ b/sites/cgk02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'cgk02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS139190',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'ID',
+    metro: 'cgk',
+    city: 'Jakarta',
+    state: '',
+    latitude: -6.1256,
+    longitude: 106.6558,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/chs02.jsonnet
+++ b/sites/chs02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'chs02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'chs',
+    city: 'Charleston',
+    state: 'SC',
+    latitude: 32.8986,
+    longitude: -80.0406,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/dfw12.jsonnet
+++ b/sites/dfw12.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'dfw12',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'dfw',
+    city: 'Dallas',
+    state: 'TX',
+    latitude: 32.8969,
+    longitude: -97.0381,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/doh02.jsonnet
+++ b/sites/doh02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'doh02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'QA',
+    metro: 'doh',
+    city: 'Doha',
+    state: '',
+    latitude: 25.2731,
+    longitude: 51.6081,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/gru06.jsonnet
+++ b/sites/gru06.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'gru06',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'SA',
+    country_code: 'BR',
+    metro: 'gru',
+    city: 'Sao Paulo',
+    state: '',
+    latitude: -23.4305,
+    longitude: -46.473,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/hel02.jsonnet
+++ b/sites/hel02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'hel02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'FI',
+    metro: 'hel',
+    city: 'Helsinki',
+    state: '',
+    latitude: 60.3172,
+    longitude: 24.9633,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/icn02.jsonnet
+++ b/sites/icn02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'icn02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'AS',
+    country_code: 'KR',
+    metro: 'icn',
+    city: 'Seoul',
+    state: '',
+    latitude: 37.4633,
+    longitude: 126.44,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/lax10.jsonnet
+++ b/sites/lax10.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'lax10',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'US',
+    metro: 'lax',
+    city: 'Los Angeles',
+    state: 'CA',
+    latitude: 33.9425,
+    longitude: -118.4072,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/waw02.jsonnet
+++ b/sites/waw02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'waw02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'PL',
+    metro: 'waw',
+    city: 'Warsaw',
+    state: '',
+    latitude: 52.1658,
+    longitude: 20.9672,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/yul08.jsonnet
+++ b/sites/yul08.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'yul08',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'NA',
+    country_code: 'CA',
+    metro: 'yul',
+    city: 'Montreal',
+    state: '',
+    latitude: 45.4576,
+    longitude: -73.7497,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+

--- a/sites/zrh02.jsonnet
+++ b/sites/zrh02.jsonnet
@@ -1,0 +1,39 @@
+local sitesDefault = import 'sites/_default_virtual.jsonnet';
+
+sitesDefault {
+  name: 'zrh02',
+  annotations+: {
+    provider: 'gcp',
+  },
+  machines+: {
+    mlab1+: {
+      network+: {
+        ipv4+: {
+          address: '192.168.0.1/32',
+        },
+        ipv6+: {
+          address: nil,
+        },
+      },
+      project: 'mlab-oti',
+    },
+  },
+  transit+: {
+    provider: 'Google LLC',
+    uplink: '1g',
+    asn: 'AS396982',
+  },
+  location+: {
+    continent_code: 'EU',
+    country_code: 'CH',
+    metro: 'zrh',
+    city: 'Zurich',
+    state: '',
+    latitude: 47.4647,
+    longitude: 8.5492,
+  },
+  lifecycle+: {
+    created: '2024-03-25',
+  },
+}
+


### PR DESCRIPTION
I'm trying this as a new strategy for deploying virtual sites. The old way was to create the resources in GCP using terraform-support, then note the static IPs created by GCP, then create the siteinfo records. The problem with this is that once the GCP resources are created, they join the cluster and start running workloads. Some of these workloads faile (namely uuid-annotator) because the site doesn't yet exist in siteinfo. This causes production alerts that cannot be managed with GMX, since GMX will not put anything into maintenance that doesn't exist in siteinfo.

The idea here is to create the site here in siteinfo, with an RFC1918 IPv4 address and no IPv6 address, and then push this through to production. Once this is in production, then an operator should place the sites into GMX maintenance mode, then run the terraform-support deployment to actually create the resources.

This is still not perfect because deploying siteinfo triggers a build in prometheus-support, which updates monitoring targets. Monitoring will then start probing machines that don't exist, with non-public IP addresses. This may not, but has the potential to cause alerts to fire. Additionally, GMX only reloads siteinfo data about every 5h, with an actual window of anywhere from 1 to 24h. This means that even though the machines are in siteinfo, GMX may still refuse to add them to maintenance unless it has already refreshed its copy of siteinfo. It may be necessary to manually restart GMX in production in these cases to ensure it has the latest version of siteinfo data so that the new sites can be put into maintenance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/327)
<!-- Reviewable:end -->
