### PR TITLE
Adds real IPs for 2nd wave of MIGs in production

### DIFF
--- a/sites/bom06.jsonnet
+++ b/sites/bom06.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.100.217.193/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:40a0:f2f2:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/cgk02.jsonnet
+++ b/sites/cgk02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.101.195.148/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1901:8170:40d1:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/chs02.jsonnet
+++ b/sites/chs02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '104.196.56.215/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:4020:5b68:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/dfw12.jsonnet
+++ b/sites/dfw12.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.174.102.230/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1901:8140:9cd3:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/doh02.jsonnet
+++ b/sites/doh02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.18.62.214/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1901:81c0:7ec:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/gru06.jsonnet
+++ b/sites/gru06.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.151.250.148/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:40f0:7602:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/hel02.jsonnet
+++ b/sites/hel02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.88.65.125/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:4150:c32e:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/icn02.jsonnet
+++ b/sites/icn02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.64.135.10/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1901:8180:af78:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/lax10.jsonnet
+++ b/sites/lax10.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.102.107.77/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:4120:30e8:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/waw02.jsonnet
+++ b/sites/waw02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.116.246.86/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:4140:a999:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/yul08.jsonnet
+++ b/sites/yul08.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.47.17.153/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:40e0:7615:8000::/128',
         },
       },
       project: 'mlab-oti',

--- a/sites/zrh02.jsonnet
+++ b/sites/zrh02.jsonnet
@@ -9,10 +9,10 @@ sitesDefault {
     mlab1+: {
       network+: {
         ipv4+: {
-          address: '192.168.0.1/32',
+          address: '34.65.218.219/32',
         },
         ipv6+: {
-          address: null,
+          address: '2600:1900:4160:623a:8000::/128',
         },
       },
       project: 'mlab-oti',


### PR DESCRIPTION
Previously, the sites were added with placeholder addresses until the resources were actually created and we knew what the actual public IPs would be.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/329)
<!-- Reviewable:end -->
