### PR TITLE
Add new site HNL02, retroactively retires HNL01

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -51,6 +51,7 @@ local retiredSites = {
   hnd03: import 'sites/hnd03.jsonnet',
   hnd04: import 'sites/hnd04.jsonnet',
   hnd06: import 'sites/hnd06.jsonnet',
+  hnl01: import 'sites/hnl01.jsonnet',
   iad01: import 'sites/iad01.jsonnet',
   iad05: import 'sites/iad05.jsonnet',
   iad06: import 'sites/iad06.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -68,7 +68,7 @@ local sites = {
   hnd02: import 'sites/hnd02.jsonnet',
   hnd05: import 'sites/hnd05.jsonnet',
   hnd07: import 'sites/hnd07.jsonnet',
-  hnl01: import 'sites/hnl01.jsonnet',
+  hnl02: import 'sites/hnl02.jsonnet',
   iad02: import 'sites/iad02.jsonnet',
   iad03: import 'sites/iad03.jsonnet',
   iad04: import 'sites/iad04.jsonnet',

--- a/sites/hnl02.jsonnet
+++ b/sites/hnl02.jsonnet
@@ -1,7 +1,7 @@
 local sitesDefault = import 'sites/_default.jsonnet';
 
 sitesDefault {
-  name: 'hnl01',
+  name: 'hnl02',
   annotations+: {
     type: 'physical',
   },
@@ -21,16 +21,16 @@ sitesDefault {
   },
   network+: {
     ipv4+: {
-      prefix: '74.199.156.192/26',
+      prefix: '38.64.64.64/26',
     },
     ipv6+: {
-      prefix: '2001:668:1f:fe06::/64',
+      prefix: '2001:550:a03::/64',
     },
   },
   transit+: {
-    provider: 'GTT Communications Inc.',
+    provider: 'Cogent Communications',
     uplink: '10g',
-    asn: 'AS3257',
+    asn: 'AS174',
   },
   location+: {
     continent_code: 'NA',
@@ -42,7 +42,7 @@ sitesDefault {
     longitude: -157.9240,
   },
   lifecycle+: {
-    created: '2021-08-24',
-    retired: '2022-06-15',
+    created: '2024-04-02',
   },
 }
+


### PR DESCRIPTION
HNL01 was a GTT site that was only operational for about a year. It went offline in June of 2022, but remained here in siteinfo. This PR retroactively retires HNL01 with the date that it actually went offline.

HNL01 is being replaced by HNL02. The hardware is the same, but HNL02's circuit is provided by Cogent and has completely different IPs than HNL01.