### PR TITLE
Don't generate switch targets for sites without a switch 

### DIFF
--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -443,6 +443,11 @@ def select_prometheus_site_targets(sites, select_regex, target_templates,
             continue
         if only_physical and site['annotations']['type'] != 'physical':
             continue
+        # If the target is a switch, and the site's switch field value is
+        # None, then skip it. The site is probably a minimal physical site
+        # without a switch or a BYOS physical site.
+        if site['switch'] == None and target_templates[0].startswith("s1-"):
+            continue
         labels = common_labels.copy()
         labels['site'] = site['name']
         targets = []

--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -443,10 +443,10 @@ def select_prometheus_site_targets(sites, select_regex, target_templates,
             continue
         if only_physical and site['annotations']['type'] != 'physical':
             continue
-        # If the target is a switch, and the site's switch field value is
-        # None, then skip it. The site is probably a minimal physical site
-        # without a switch or a BYOS physical site.
-        if site['switch'] == None and target_templates[0].startswith("s1-"):
+        # If the target is a switch, and the site's switch field value is None,
+        # then skip it. The site is probably a minimal physical site without a
+        # switch or a BYOS physical site.
+        if only_physical and site['switch'] == None and target_templates[0].startswith("s1"):
             continue
         labels = common_labels.copy()
         labels['site'] = site['name']

--- a/cmd/mlabconfig.py
+++ b/cmd/mlabconfig.py
@@ -446,8 +446,9 @@ def select_prometheus_site_targets(sites, select_regex, target_templates,
         # If the target is a switch, and the site's switch field value is None,
         # then skip it. The site is probably a minimal physical site without a
         # switch or a BYOS physical site.
-        if only_physical and site['switch'] == None and target_templates[0].startswith("s1"):
-            continue
+        if 'switch' in site:
+            if site['switch'] == None and target_templates[0].startswith("s1"):
+                continue
         labels = common_labels.copy()
         labels['site'] = site['name']
         targets = []

--- a/cmd/mlabconfig_test.py
+++ b/cmd/mlabconfig_test.py
@@ -166,7 +166,25 @@ sites = [
                "subnet": 64
             }
          },
-      ]
+      ],
+      "switch": {
+        "auto_negotiation": "yes",
+        "flow_control": "no",
+        "make": "juniper",
+        "model": "qfx5100",
+        "rstp": "yes",
+        "uplink_port": "xe-0/0/45",
+      },
+    },
+]
+
+site_no_switch = [
+   {
+      "name": "xyz0t",
+      "annotations": {
+         "type": "physical"
+      },
+      "switch": None,
    },
 ]
 
@@ -175,6 +193,7 @@ class MlabconfigTest(unittest.TestCase):
     def setUp(self):
         self.users = [('User', 'Name', 'username@gmail.com')]
         self.sites = sites
+        self.site_no_switch = site_no_switch
         # Turn off logging output during testing (unless CRITICAL).
         logging.disable(logging.ERROR)
 
@@ -415,9 +434,10 @@ class MlabconfigTest(unittest.TestCase):
             }
         ]
 
+        sites = self.sites + self.site_no_switch
         actual_targets = mlabconfig.select_prometheus_site_targets(
-            self.sites, None, ['s1.{{sitename}}.measurement-lab.org:9116'], {},
-            False)
+            sites, None, ['s1.{{sitename}}.measurement-lab.org:9116'], {},
+            True)
 
         self.assertEqual(len(actual_targets), 1)
         self.assertCountEqual(actual_targets, expected_targets)


### PR DESCRIPTION
Now that we are supporting minimal physical sites without a switch, we don't want to generate Prometheus switch targets for these sites. This PR adds a simple conditional to check whether the siteinfo value for "switch" is None ("null" in the JSON), and whether the target begins with "s1", which would`indicate a switch target.