### PR TITLE
Add zone delegation for autojoin.measurement-lab.org.

### DIFF
--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -43,7 +43,7 @@ std.lines([
                      IN     NS      ns-cloud-a2.googledomains.com.
                      IN     NS      ns-cloud-a3.googledomains.com.
                      IN     NS      ns-cloud-a4.googledomains.com.
-    ; Delegate mlab-oti subdomain to staging Cloud DNS servers.
+    ; Delegate mlab-oti subdomain to production Cloud DNS servers.
     mlab-oti         IN     NS      ns-cloud-d1.googledomains.com.
                      IN     NS      ns-cloud-d2.googledomains.com.
                      IN     NS      ns-cloud-d3.googledomains.com.

--- a/formats/v2/zones/measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/measurement-lab.org.zone.jsonnet
@@ -59,6 +59,10 @@ std.lines([
                      IN     NS      ns-cloud-b2.googledomains.com.
                      IN     NS      ns-cloud-b3.googledomains.com.
                      IN     NS      ns-cloud-b4.googledomains.com.
+    autojoin         IN     NS      ns-cloud-a1.googledomains.com.
+                     IN     NS      ns-cloud-a2.googledomains.com.
+                     IN     NS      ns-cloud-a3.googledomains.com.
+                     IN     NS      ns-cloud-a4.googledomains.com.
   |||,
 ] + [
   '%-32s  IN  A   \t%s' % [row.record, row.ipv4]

--- a/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
+++ b/formats/v2/zones/projects_measurement-lab.org.zone.jsonnet
@@ -108,7 +108,10 @@ local primary_headers = |||
                    IN     NS      ns-cloud-b2.googledomains.com.
                    IN     NS      ns-cloud-b3.googledomains.com.
                    IN     NS      ns-cloud-b4.googledomains.com.
-
+  autojoin         IN     NS      ns-cloud-a1.googledomains.com.
+                   IN     NS      ns-cloud-a2.googledomains.com.
+                   IN     NS      ns-cloud-a3.googledomains.com.
+                   IN     NS      ns-cloud-a4.googledomains.com.
 
   ;
   ; Delegate acme subdomains to Cloud DNS servers.


### PR DESCRIPTION
This adds the autojoin zone delegations for `autojoin.measurement-lab.org` (https://github.com/m-lab/siteinfo/pull/326 and https://github.com/m-lab/siteinfo/pull/325 are previous PRs adding zone delegation for sandbox/staging).

See [here](https://console.cloud.google.com/net-services/dns/zones/autojoin-measurement-lab-org/details?project=mlab-autojoin) for the zone's configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/335)
<!-- Reviewable:end -->
