### PR TITLE
Reduce probability to 50% for select virtual sites

### DIFF
--- a/sites/ams10.jsonnet
+++ b/sites/ams10.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'ams10',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/bom03.jsonnet
+++ b/sites/bom03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'bom03',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/bom05.jsonnet
+++ b/sites/bom05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'bom05',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/bom06.jsonnet
+++ b/sites/bom06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'bom06',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/bru06.jsonnet
+++ b/sites/bru06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'bru06',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/del05.jsonnet
+++ b/sites/del05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'del05',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/dfw09.jsonnet
+++ b/sites/dfw09.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'dfw09',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/dfw12.jsonnet
+++ b/sites/dfw12.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'dfw12',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/fra07.jsonnet
+++ b/sites/fra07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'fra07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/gru05.jsonnet
+++ b/sites/gru05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'gru05',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/gru06.jsonnet
+++ b/sites/gru06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'gru06',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/hkg04.jsonnet
+++ b/sites/hkg04.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'hkg04',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/hnd07.jsonnet
+++ b/sites/hnd07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'hnd07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/iad09.jsonnet
+++ b/sites/iad09.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'iad09',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/jnb02.jsonnet
+++ b/sites/jnb02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'jnb02',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/lax07.jsonnet
+++ b/sites/lax07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'lax07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/lax10.jsonnet
+++ b/sites/lax10.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'lax10',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/lhr10.jsonnet
+++ b/sites/lhr10.jsonnet
@@ -3,7 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'lhr10',
   annotations+: {
-    type: 'virtual',
+    probability: 0.5,
     provider: 'gcp',
   },
   machines: {

--- a/sites/mad07.jsonnet
+++ b/sites/mad07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'mad07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/mil08.jsonnet
+++ b/sites/mil08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'mil08',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/par08.jsonnet
+++ b/sites/par08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'par08',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/scl06.jsonnet
+++ b/sites/scl06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'scl06',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/sin02.jsonnet
+++ b/sites/sin02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'sin02',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/syd08.jsonnet
+++ b/sites/syd08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'syd08',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/tpe02.jsonnet
+++ b/sites/tpe02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'tpe02',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/trn03.jsonnet
+++ b/sites/trn03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'trn03',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/yul07.jsonnet
+++ b/sites/yul07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'yul07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/yul08.jsonnet
+++ b/sites/yul08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'yul08',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/yyz07.jsonnet
+++ b/sites/yyz07.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'yyz07',
   annotations+: {
+    probability: 0.5,
     provider: 'gcp',
   },
   machines+: {


### PR DESCRIPTION
The virtual sites affected by this PR are in metros where M-Lab currently has at least one or more physical sites. The idea is to push more clients to the physical site(s) in these metros, since those costs are fixed. Setting these sites to 50% probability should save quite a lot of GCP Internet egress traffic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/336)
<!-- Reviewable:end -->
