### PR TITLE
Adds new donated=[true|false] site annotations + adds core "experiment" flooefi

### DIFF
--- a/experiments.jsonnet
+++ b/experiments.jsonnet
@@ -37,7 +37,7 @@ local default = {
   },
   default {
     index: 7,
-    name: 'demo7',
+    name: 'flooefi',
   },
   default {
     index: 8,

--- a/formats/v2/sites/donated.json.jsonnet
+++ b/formats/v2/sites/donated.json.jsonnet
@@ -1,0 +1,7 @@
+local sites = import 'sites.jsonnet';
+
+[
+  site.name
+  for site in sites
+  if site.annotations.donated == true
+]

--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -3,9 +3,10 @@ local site = import 'lib/site.jsonnet';
 site {
   name: error 'Must override site name',
   annotations: {
+    donated: false,
+    probability: 1.0,
     provider: 'mlab',
     type: 'physical',
-    probability: 1.0,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/_default_virtual.jsonnet
+++ b/sites/_default_virtual.jsonnet
@@ -3,9 +3,10 @@ local site = import 'lib/site_virtual.jsonnet';
 site {
   name: error 'Must override site name',
   annotations: {
+    donated: false,
+    probability: 1.0,
     provider: 'mlab',
     type: 'virtual',
-    probability: 1.0,
   },
   loadbalancer: {
     roundrobin: true,

--- a/sites/akl01.jsonnet
+++ b/sites/akl01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'akl01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/ath03.jsonnet
+++ b/sites/ath03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'ath03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/atl02.jsonnet
+++ b/sites/atl02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'atl02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/bcn01.jsonnet
+++ b/sites/bcn01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'bcn01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/beg01.jsonnet
+++ b/sites/beg01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'beg01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/cpt01.jsonnet
+++ b/sites/cpt01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'cpt01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/dfw08.jsonnet
+++ b/sites/dfw08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'dfw08',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/dub01.jsonnet
+++ b/sites/dub01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'dub01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/fln01.jsonnet
+++ b/sites/fln01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'fln01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/fra03.jsonnet
+++ b/sites/fra03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'fra03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/geg01.jsonnet
+++ b/sites/geg01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'geg01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/hkg03.jsonnet
+++ b/sites/hkg03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'hkg03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/hnl02.jsonnet
+++ b/sites/hnl02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'hnl02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/iad02.jsonnet
+++ b/sites/iad02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'iad02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/jnb01.jsonnet
+++ b/sites/jnb01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'jnb01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/lax06.jsonnet
+++ b/sites/lax06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'lax06',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/lga08.jsonnet
+++ b/sites/lga08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'lga08',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/lhr04.jsonnet
+++ b/sites/lhr04.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'lhr04',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/lju01.jsonnet
+++ b/sites/lju01.jsonnet
@@ -3,8 +3,9 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'lju01',
   annotations+: {
-    type: 'physical',
+    donated: true,
     probability: 0.5,
+    type: 'physical',
   },
   machines+: {
     mlab1+: {

--- a/sites/mex01.jsonnet
+++ b/sites/mex01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mex01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mex04.jsonnet
+++ b/sites/mex04.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mex04',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mia02.jsonnet
+++ b/sites/mia02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mia02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mil05.jsonnet
+++ b/sites/mil05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mil05',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mnl01.jsonnet
+++ b/sites/mnl01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mnl01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mnl02.jsonnet
+++ b/sites/mnl02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mnl02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mpm02.jsonnet
+++ b/sites/mpm02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mpm02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/mty01.jsonnet
+++ b/sites/mty01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'mty01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/nbo01.jsonnet
+++ b/sites/nbo01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'nbo01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/nuq03.jsonnet
+++ b/sites/nuq03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'nuq03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/nuq08.jsonnet
+++ b/sites/nuq08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'nuq08',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines: {

--- a/sites/ord02.jsonnet
+++ b/sites/ord02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'ord02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/par05.jsonnet
+++ b/sites/par05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'par05',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/pdx02.jsonnet
+++ b/sites/pdx02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'pdx02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/per01.jsonnet
+++ b/sites/per01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'per01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/sea08.jsonnet
+++ b/sites/sea08.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'sea08',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/sea10.jsonnet
+++ b/sites/sea10.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'sea10',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/svg01.jsonnet
+++ b/sites/svg01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'svg01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/syd03.jsonnet
+++ b/sites/syd03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'syd03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/syd05.jsonnet
+++ b/sites/syd05.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'syd05',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/tgd01.jsonnet
+++ b/sites/tgd01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'tgd01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/tnr01.jsonnet
+++ b/sites/tnr01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'tnr01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/tpe01.jsonnet
+++ b/sites/tpe01.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'tpe01',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/trn02.jsonnet
+++ b/sites/trn02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'trn02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/tun01.jsonnet
+++ b/sites/tun01.jsonnet
@@ -3,8 +3,9 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'tun01',
   annotations+: {
-    type: 'physical',
+    donated: true,
     probability: 0.5,
+    type: 'physical',
   },
   machines+: {
     mlab1+: {

--- a/sites/wlg02.jsonnet
+++ b/sites/wlg02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'wlg02',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/yul06.jsonnet
+++ b/sites/yul06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'yul06',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/yvr03.jsonnet
+++ b/sites/yvr03.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'yvr03',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {

--- a/sites/yyz06.jsonnet
+++ b/sites/yyz06.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default.jsonnet';
 sitesDefault {
   name: 'yyz06',
   annotations+: {
+    donated: true,
     type: 'physical',
   },
   machines+: {


### PR DESCRIPTION
This PR adds a new `donated=[true|false]` site annotation. It provides us an easy and programmatic way to determine which sites are donated. There is a new "donated.json" format, to list all donated sites.

This PR also adds a new, temporary experiment named "flooefi", which will allow Google to continue to test using this service on the M-Lab platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/337)
<!-- Reviewable:end -->
