### PR TITLE
Add mel01 site back

### DIFF
--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -106,6 +106,7 @@ local sites = {
   mad06: import 'sites/mad06.jsonnet',
   mad07: import 'sites/mad07.jsonnet',
   mad08: import 'sites/mad08.jsonnet',
+  mel01: import 'sites/mel01.jsonnet',
   mel02: import 'sites/mel02.jsonnet',
   mex01: import 'sites/mex01.jsonnet',
   mex03: import 'sites/mex03.jsonnet',


### PR DESCRIPTION
This PR adds the `mel01` site back to the `sites` list. This site was deleted, seemingly by mistake, when the round 3 MIGs were added https://github.com/m-lab/siteinfo/pull/340/files. This is causing the pod to crash loop.

In the future, if the site does get removed, it will have to go under the `retired` list, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/341)
<!-- Reviewable:end -->
