### PR TITLE
Retires standalone VM site BOM05

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -24,6 +24,7 @@ local retiredSites = {
   bkk01: import 'sites/bkk01.jsonnet',
   bog01: import 'sites/bog01.jsonnet',
   bom03: import 'sites/bom03.jsonnet',
+  bom05: import 'sites/bom05.jsonnet',
   bru03: import 'sites/bru03.jsonnet',
   bru05: import 'sites/bru05.jsonnet',
   bru06: import 'sites/bru06.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -20,7 +20,6 @@ local sites = {
   bom01: import 'sites/bom01.jsonnet',
   bom02: import 'sites/bom02.jsonnet',
   bom04: import 'sites/bom04.jsonnet',
-  bom05: import 'sites/bom05.jsonnet',
   bom06: import 'sites/bom06.jsonnet',
   bru01: import 'sites/bru01.jsonnet',
   bru02: import 'sites/bru02.jsonnet',

--- a/sites/bom05.jsonnet
+++ b/sites/bom05.jsonnet
@@ -63,5 +63,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2023-11-13',
+    retired: '2024-08-13',
   },
 }


### PR DESCRIPTION
We already have MIG BOM06 in BOM, and don't need a 3-VM standalone site here. This got skipped over in the MIG migrations somehow because MIG BOM06 already existed, so I didn't try to migrate BOM05, but forgot to remove it anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/345)
<!-- Reviewable:end -->
