### PR TITLE
Changes default switch model to qfx5100-48s

### DIFF
--- a/sites/_default.jsonnet
+++ b/sites/_default.jsonnet
@@ -58,10 +58,12 @@ site {
     auto_negotiation: 'yes',
     flow_control: 'no',
     make: 'juniper',
-    model: 'qfx5100',
+    model: 'qfx5100-48s',
     rstp: 'yes',
     uplink_port: (
-      if $.transit.uplink == '10g' then
+      if $.transit.uplink == '40g' then
+        'et-0/0/23'
+      else if $.transit.uplink == '10g' then
         'xe-0/0/45'
       else if $.transit.uplink == '1g' then
         'ge-0/0/47'

--- a/sites/geg01.jsonnet
+++ b/sites/geg01.jsonnet
@@ -30,7 +30,7 @@ sitesDefault {
   },
   transit+: {
     provider: '"Wholesail networks LLC',
-    uplink: '10g',
+    uplink: '40g',
     asn: 'AS20055',
   },
   location+: {
@@ -41,6 +41,9 @@ sitesDefault {
     state: 'WA',
     latitude: 47.6200,
     longitude: -117.5339,
+  },
+  switch+: {
+    model: 'qfx5100-24q',
   },
   lifecycle+: {
     created: '2024-04-22',

--- a/sites/pdx02.jsonnet
+++ b/sites/pdx02.jsonnet
@@ -30,7 +30,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Wholesail networks LLC',
-    uplink: '10g',
+    uplink: '40g',
     asn: 'AS20055',
   },
   location+: {
@@ -41,6 +41,9 @@ sitesDefault {
     state: 'OR',
     latitude: 45.5886,
     longitude: -122.5975,
+  },
+  switch+: {
+    model: 'qfx5100-24q',
   },
   lifecycle+: {
     created: '2024-04-22',

--- a/sites/sea10.jsonnet
+++ b/sites/sea10.jsonnet
@@ -30,7 +30,7 @@ sitesDefault {
   },
   transit+: {
     provider: 'Wholesail networks LLC',
-    uplink: '10g',
+    uplink: '40g',
     asn: 'AS20055',
   },
   location+: {
@@ -41,6 +41,9 @@ sitesDefault {
     state: 'WA',
     latitude: 47.4489,
     longitude: -122.3094,
+  },
+  switch+: {
+    model: 'qfx5100-24q',
   },
   lifecycle+: {
     created: '2024-04-22',


### PR DESCRIPTION
The new Ziply "full" sites in Portland (PDX02), Seattle (SEA10) and Spokane (GEG01) are going to be using Juniper QFX5100-24Q switches, and will be on 40Gbps uplinks. This commit adds the suffix "-48s" to the default switch model for physical sites. The new Ziply sites will have a model of "qfx5100-24q". The switch-config repository will be configured with a new template for the 24Q model.

As far as I know, the only thing that currently uses the "model" field from switches.json is genconfig.py in the switch-config repository. @robertodauria, does this match your understanding? I want to be sure that this change doesn't break something else that consumes switches.json.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/348)
<!-- Reviewable:end -->
