### PR TITLE
Produces sites.json, but for retired sites in v2 format

### DIFF
--- a/formats/v2/retired/placeholder.json.jsonnet
+++ b/formats/v2/retired/placeholder.json.jsonnet
@@ -1,2 +1,0 @@
-// Create an empty placeholder format to allow Makefile to WAI.
-{}

--- a/formats/v2/retired/sites.json.jsonnet
+++ b/formats/v2/retired/sites.json.jsonnet
@@ -1,0 +1,21 @@
+local experiments = import 'experiments.jsonnet';
+local sites = if std.extVar('retired') then import 'retired.jsonnet' else import 'sites.jsonnet';
+
+[
+  site {
+    nodes: [
+      local m = site.Machine(machine);
+      local expCount = site.ExperimentCount();
+      m {
+        hostname: m.Hostname(),
+        experiments: std.prune([
+          site.Experiment(machine, experiment)
+          for experiment in experiments[:expCount]
+        ]),
+      }
+      for machine in std.objectFields(site.machines)
+    ],
+  }
+  for site in sites
+]
+


### PR DESCRIPTION
I had a need to collect information about retired sites. Specifically, how many physical sites were retired for a given set of years.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/352)
<!-- Reviewable:end -->
