### PR TITLE
Spill 75% of Osaka (kix) and Columbus (cmh) to less expensive sites

### DIFF
--- a/sites/cmh02.jsonnet
+++ b/sites/cmh02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'cmh02',
   annotations+: {
+    probability: 0.25,
     provider: 'gcp',
   },
   machines+: {

--- a/sites/kix02.jsonnet
+++ b/sites/kix02.jsonnet
@@ -3,6 +3,7 @@ local sitesDefault = import 'sites/_default_virtual.jsonnet';
 sitesDefault {
   name: 'kix02',
   annotations+: {
+    probability: 0.25,
     provider: 'gcp',
   },
   machines+: {


### PR DESCRIPTION
Mostly spill Osaka (kix)  to Tokyo (hnd) and Seoul (icn). 
Mostly spill Columbus (cmh) to Chicago (ord), Washington (iad) and Toronto (yyz).

The alternate sites are all include substantial flatrate serving (non-GCS) sites.

Seoul also has relatively expensive GCS egress, however it already carries the the majority of Korean traffic.  Japan traffic is expected to spill to Tokyo, which is mostly physical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/361)
<!-- Reviewable:end -->
