### PR TITLE
Retires site AMS04

### DIFF
--- a/retired.jsonnet
+++ b/retired.jsonnet
@@ -4,6 +4,7 @@ local retiredSites = {
   ams01: import 'sites/ams01.jsonnet',
   ams02: import 'sites/ams02.jsonnet',
   ams03: import 'sites/ams03.jsonnet',
+  ams04: import 'sites/ams04.jsonnet',
   ams06: import 'sites/ams06.jsonnet',
   ams07: import 'sites/ams07.jsonnet',
   ams08: import 'sites/ams08.jsonnet',

--- a/sites.jsonnet
+++ b/sites.jsonnet
@@ -1,7 +1,6 @@
 local sites = {
   // Physical sites.
   akl01: import 'sites/akl01.jsonnet',
-  ams04: import 'sites/ams04.jsonnet',
   ams05: import 'sites/ams05.jsonnet',
   ams11: import 'sites/ams11.jsonnet',
   arn02: import 'sites/arn02.jsonnet',

--- a/sites/ams04.jsonnet
+++ b/sites/ams04.jsonnet
@@ -43,5 +43,6 @@ sitesDefault {
   },
   lifecycle+: {
     created: '2019-01-01',
+    retired: '2026-01-13',
   },
 }


### PR DESCRIPTION
The site has been down since Nov 2024 and there is little to no hope of us ever recovering it at this point. I'm not even sure if the circuit still exists or whether the contract may have even expired by now. In any case, there is no point in having a site on the platform that has been down for 1+ years virtually no hope of recovering it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/siteinfo/365)
<!-- Reviewable:end -->
